### PR TITLE
Ticket #30818 - Fix for the wrong base pipeline configuration

### DIFF
--- a/python/tk_framework_desktopserver/command.py
+++ b/python/tk_framework_desktopserver/command.py
@@ -52,7 +52,13 @@ class Command(object):
             else:
                 startupinfo = None
 
-            # Clean out Toolkit specific environment variables to launch the process cleanly
+            # The commands that are being run are probably being launched from Desktop, which would
+            # have a TANK_CURRENT_PC environment variable set to the site configuration. Since we
+            # preserve that value for subprocesses (which is usually the behavior we want), the DCCs
+            # being launched would try to run in the project environment and would get an error due
+            # to the conflict.
+            #
+            # Clean up the environment to prevent that from happening.
             env = os.environ.copy()
             vars_to_remove = ["TANK_CURRENT_PC"]
             for var in vars_to_remove:

--- a/python/tk_framework_desktopserver/command.py
+++ b/python/tk_framework_desktopserver/command.py
@@ -8,6 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+import os
 import subprocess
 from threading import Thread
 from Queue import Queue
@@ -50,10 +51,19 @@ class Command(object):
                 startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
             else:
                 startupinfo = None
+
+            # Clean out Toolkit specific environment variables to launch the process cleanly
+            env = os.environ.copy()
+            vars_to_remove = ["TANK_CURRENT_PC"]
+            for var in vars_to_remove:
+                if var in env:
+                    del env[var]
+
             process = subprocess.Popen(
                 args,
                 stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                startupinfo=startupinfo
+                startupinfo=startupinfo,
+                env=env,
             )
             process.stdin.close()
 


### PR DESCRIPTION
The commands that are being run are being launched from Desktop, which would have a TANK_CURRENT_PC env var set to the site configuration.  Since we preserve that value for subprocesses (which is usually the behavior we want), the DCCs being launched were trying to run in the project environment and getting an error due to the conflict.

This change updates the logic for launching commands from the webserver to make sure that subprocesses run with a clean environment.