### PR TITLE
For #31081, cleanly shutdown websockets

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -112,7 +112,7 @@ if __name__ == '__main__':
         keys_path=os.environ.get("TANK_DESKTOP_INTEGRATION_CERTIFICATE", "../resources/keys"),
         port=os.environ.get("TANK_DESKTOP_INTEGRATION_PORT", 9000)
     )
-    server.start(start_reactor=True)
+    server.start()
 
     # Enables CTRL-C to kill this process even tough Qt doesn't know how to play nice with Python.
     # As per this stack overflow comment

--- a/python/tk_framework_desktopserver/command.py
+++ b/python/tk_framework_desktopserver/command.py
@@ -12,16 +12,31 @@ import os
 import subprocess
 from threading import Thread
 from Queue import Queue
+import tempfile
 import sys
+from . logger import get_logger
 
 
 class ReadThread(Thread):
+    """
+    Thread that reads a pipe.
+    """
     def __init__(self, p_out, target_queue):
+        """
+        Constructor.
+
+        :param p_out: Pipe to read.
+        :param target_queue: Queue that will accumulate the pipe output.
+        """
         Thread.__init__(self)
         self.pipe = p_out
         self.target_queue = target_queue
 
     def run(self):
+        """
+        Reads the contents of the pipe and adds it to the queue until the pipe
+        is closed.
+        """
         while True:
             line = self.pipe.readline()         # blocking read
             if line == '':
@@ -32,44 +47,71 @@ class ReadThread(Thread):
 class Command(object):
 
     @staticmethod
-    def _enqueue_output(out, queue):
-        for line in iter(out.readline, b''):
-            queue.put(line)
-        out.close()
+    def _create_temp_file():
+        """
+        :returns: Returns the path to a temporary file.
+        """
+        handle, path = tempfile.mkstemp()
+        os.close(handle)
+        return path
 
     @staticmethod
     def call_cmd(args):
+        """
+        Runs a command in a separate process.
+
+        :param args: Command line tokens.
+
+        :returns: A tuple containing (exit code, stdout, stderr).
+        """
+        # The commands that are being run are probably being launched from Desktop, which would
+        # have a TANK_CURRENT_PC environment variable set to the site configuration. Since we
+        # preserve that value for subprocesses (which is usually the behavior we want), the DCCs
+        # being launched would try to run in the project environment and would get an error due
+        # to the conflict.
+        #
+        # Clean up the environment to prevent that from happening.
+        env = os.environ.copy()
+        vars_to_remove = ["TANK_CURRENT_PC"]
+        for var in vars_to_remove:
+            if var in env:
+                del env[var]
+
+        # Launch the child process
+        # Due to discrepencies on how child file descriptors and shell=True are
+        # handled on Windows and Unix, we'll provide two implementations. See the Windows
+        # implementation for more details.
+        if sys.platform == "win32":
+            ret, stdout_lines, stderr_lines = Command._call_cmd_win32(args, env)
+        else:
+            ret, stdout_lines, stderr_lines = Command._call_cmd_unix(args, env)
+
+        out = ''.join(stdout_lines)
+        err = ''.join(stderr_lines)
+
+        return ret, out, err
+
+    @staticmethod
+    def _call_cmd_unix(args, env):
+        """
+        Runs a command in a separate process. Implementation for Unix based OSes.
+
+        :param args: Command line tokens.
+        :param env: Environment variables to set for the subprocess.
+
+        :returns: A tuple containing (exit code, stdout, stderr).
+        """
         # Note: Tie stdin to a PIPE as well to avoid this python bug on windows
         # http://bugs.python.org/issue3905
         # Queue code taken from: http://stackoverflow.com/questions/375427/non-blocking-read-on-a-subprocess-pipe-in-python
         stdout_lines = []
         stderr_lines = []
+
         try:
-            # Prevents the cmd.exe dialog from appearing on Windows.
-            if sys.platform == 'win32':
-                startupinfo = subprocess.STARTUPINFO()
-                startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-            else:
-                startupinfo = None
-
-            # The commands that are being run are probably being launched from Desktop, which would
-            # have a TANK_CURRENT_PC environment variable set to the site configuration. Since we
-            # preserve that value for subprocesses (which is usually the behavior we want), the DCCs
-            # being launched would try to run in the project environment and would get an error due
-            # to the conflict.
-            #
-            # Clean up the environment to prevent that from happening.
-            env = os.environ.copy()
-            vars_to_remove = ["TANK_CURRENT_PC"]
-            for var in vars_to_remove:
-                if var in env:
-                    del env[var]
-
             process = subprocess.Popen(
                 args,
                 stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                startupinfo=startupinfo,
-                env=env,
+                env=env
             )
             process.stdin.close()
 
@@ -104,13 +146,101 @@ class Command(object):
                 stderr_lines.append(stderr_q.get())
 
             ret = process.returncode
-        except StandardError:
+        except StandardError, e:
+            get_logger().exception(e)
+
             import traceback
             ret = 1
             stderr_lines = traceback.format_exc().split()
             stderr_lines.append("%s" % args)
 
-        out = ''.join(stdout_lines)
-        err = ''.join(stderr_lines)
+        return ret, stdout_lines, stderr_lines
 
-        return ret, out, err
+    @staticmethod
+    def _call_cmd_win32(args, env):
+        """
+        Runs a command in a separate process. Implementation for Windows.
+
+        :param args: Command line tokens.
+        :param env: Environment variables to set for the subprocess.
+
+        :returns: A tuple containing (exit code, stdout, stderr).
+        """
+        stdout_lines = []
+        stderr_lines = []
+        try:
+            stdout_path = Command._create_temp_file()
+            stderr_path = Command._create_temp_file()
+
+            # On Windows, file descriptors like sockets can be inherited by child
+            # process and are only closed when the main process and all child
+            # processes are closed. This is bad because it means that the port
+            # the websocket server uses will never be released as long as any DCCs
+            # or tank commands are running. Therefore, closing the Desktop and
+            # restarting it for example wouldn't free the port and would give the
+            # "port 9000 already in use" error we've seen before.
+
+            # To avoid this, close_fds needs to be specified when launching a child
+            # process. However, there's a catch. On Windows, specifying close_fds
+            # also means that you can't share stdout, stdin and stderr with the child
+            # process, which is required here because we want to capture the output
+            # of the process.
+
+            # Therefore on Windows we'll invoke the code in a shell environment. The
+            # output will be redirected to two temporary files which will be read
+            # when the child process is over.
+
+            # Ideally, we'd be using this implementation on Unix as well. After all,
+            # the syntax of the command line is the same. However, specifying shell=True
+            # on Unix means that the following ["ls", "-al"] would be invoked like this:
+            # ["/bin/sh", "-c", "ls", "-al"]. This means that only ls is sent to the
+            # shell and -al is considered to be an argument of the shell and not part
+            # of what needs to be launched. The naive solution would be to quote the
+            # argument list and pass ["\"ls -al \""] to Popen, but that would ignore
+            # the fact that there could already be quotes on that command line and
+            # they would need to be escaped as well. Python 2's only utility to
+            # escape strings for the command line is pipes.quote, which is deprecated.
+
+            # Because of these reasons, we'll keep both implementations for now.
+
+            args = args + ["1>", stdout_path, "2>", stderr_path]
+
+            # Prevents the cmd.exe dialog from appearing on Windows.
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+
+            process = subprocess.Popen(
+                args,
+                close_fds=True,
+                startupinfo=startupinfo,
+                env=env,
+                shell=True
+            )
+            process.wait()
+
+            # Read back the output from the two.
+            stdout_lines = [l for l in open(stdout_path)]
+            stderr_lines = [l for l in open(stderr_path)]
+
+            # Track the result code.
+            ret = process.returncode
+
+        except StandardError, e:
+            get_logger().exception(e)
+
+            import traceback
+            ret = 1
+            stderr_lines = [traceback.format_exc().split()]
+            stderr_lines.append("%s" % args)
+
+        # Don't lose any sleep over temporary files that can't be deleted.
+        try:
+            os.remove(stdout_path)
+        except:
+            pass
+        try:
+            os.remove(stderr_path)
+        except:
+            pass
+
+        return ret, stdout_lines, stderr_lines

--- a/python/tk_framework_desktopserver/server.py
+++ b/python/tk_framework_desktopserver/server.py
@@ -96,17 +96,12 @@ class Server:
         self._reactor_thread = threading.Thread(target=start)
         self._reactor_thread.start()
 
-    def start(self, start_reactor=False):
+    def start(self):
         """
         Start shotgun web server, listening to websocket connections.
-
-        :param debug: Boolean Show debug output. Will also Start local web server to test client pages.
-        :param keys_path: Path to the certificate files (.crt and .key).
-        :param start_reactor: Boolean Start threaded reactor
         """
         self._start_server()
-        if start_reactor:
-            self._start_reactor()
+        self._start_reactor()
 
     def is_running(self):
         """

--- a/python/tk_framework_desktopserver/server.py
+++ b/python/tk_framework_desktopserver/server.py
@@ -8,9 +8,9 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import sys
 import os
 import threading
+import logging
 
 from server_protocol import ServerProtocol
 
@@ -36,8 +36,18 @@ class Server:
         self._whitelist = whitelist or self._DEFAULT_WHITELIST
         self._debug = debug
 
+        self._logger_root = logging.getLogger("tk-framework-desktopserver")
+
         if self._debug:
-            log.startLogging(sys.stdout)
+            # This will take the Twisted logging and forward it to Python's logging.
+            self._observer = log.PythonLoggingObserver("tk-framework-desktopserver.twisted")
+            self._observer.start()
+
+    def get_logger(self):
+        """
+        :returns: The python logger root for the framework.
+        """
+        return self._logger_root
 
     def _raise_if_missing_certificate(self, certificate_path):
         """
@@ -83,8 +93,8 @@ class Server:
         def start():
             reactor.run(installSignalHandlers=0)
 
-        t = threading.Thread(target=start)
-        t.start()
+        self._reactor_thread = threading.Thread(target=start)
+        self._reactor_thread.start()
 
     def start(self, start_reactor=False):
         """
@@ -98,8 +108,15 @@ class Server:
         if start_reactor:
             self._start_reactor()
 
-    def stop(self):
+    def is_running(self):
         """
-        Stops the serverreactor.
+        :returns: True if the server is up and running, False otherwise.
+        """
+        return self._reactor_thread.isAlive()
+
+    def tear_down(self):
+        """
+        Tears down Twisted.
         """
         reactor.callFromThread(reactor.stop)
+        self._reactor_thread.join()


### PR DESCRIPTION
- Correctly waits for the server thread to end on shutdown.
- Forwards the Twisted logs to the Python logs.