### PR TITLE
For #30860, make websocket errors more obvious

### DIFF
--- a/python/tk_framework_desktopserver/__init__.py
+++ b/python/tk_framework_desktopserver/__init__.py
@@ -26,4 +26,4 @@ from .server import Server
 from .process_manager import ProcessManager
 from .certificates import get_certificate_handler
 from .logger import get_logger
-from .errors import MissingCertificate, PortBusy
+from .errors import MissingCertificateError, PortBusyError

--- a/python/tk_framework_desktopserver/__init__.py
+++ b/python/tk_framework_desktopserver/__init__.py
@@ -26,3 +26,4 @@ from .server import Server
 from .process_manager import ProcessManager
 from .certificates import get_certificate_handler
 from .logger import get_logger
+from .errors import MissingCertificate, PortBusy

--- a/python/tk_framework_desktopserver/certificates.py
+++ b/python/tk_framework_desktopserver/certificates.py
@@ -94,7 +94,7 @@ class _CertificateHandler(object):
             # Sometimes the is_registered_cmd will output Shotgun Software and sometimes it will
             # only output the pretty name Shotgun Desktop Integration, so searching for Shotgun is 
             # good enough.
-            subprocess.check_call(cmd, shell=True)
+            subprocess.check_call(cmd, stderr=subprocess.STDOUT, shell=True)
         except subprocess.CalledProcessError, e:
             self._logger.exception("There was a problem %s" % ctx)
             self._logger.info("Output:\n%s" % e.output)

--- a/python/tk_framework_desktopserver/certificates.py
+++ b/python/tk_framework_desktopserver/certificates.py
@@ -110,7 +110,7 @@ class _CertificateHandler(object):
             # Sometimes the is_registered_cmd will output Shotgun Software and sometimes it will
             # only output the pretty name Shotgun Desktop Integration, so searching for Shotgun is
             # good enough.
-            return "Shotgun" in subprocess.check_output(self._get_is_registered_cmd(), shell=True)
+            return "Shotgun" in subprocess.check_output(self._get_is_registered_cmd(), stderr=subprocess.STDOUT, shell=True)
         except subprocess.CalledProcessError, e:
             self._logger.exception("There was a problem validating if a certificate was installed.")
             self._logger.info("Output:\n%s" % e.output)

--- a/python/tk_framework_desktopserver/certificates.py
+++ b/python/tk_framework_desktopserver/certificates.py
@@ -13,6 +13,7 @@ import os
 import sys
 import subprocess
 import logging
+from .errors import CertificateRegistrationFailed
 
 from OpenSSL import crypto
 
@@ -98,7 +99,7 @@ class _CertificateHandler(object):
         except subprocess.CalledProcessError, e:
             self._logger.exception("There was a problem %s" % ctx)
             self._logger.info("Output:\n%s" % e.output)
-            raise
+            raise CertificateRegistrationFailed("There was a problem %s" % ctx)
 
     def is_registered(self):
         """
@@ -114,7 +115,7 @@ class _CertificateHandler(object):
         except subprocess.CalledProcessError, e:
             self._logger.exception("There was a problem validating if a certificate was installed.")
             self._logger.info("Output:\n%s" % e.output)
-            raise
+            raise CertificateRegistrationFailed("There was a problem validating if a certificate was installed.")
 
     def unregister(self):
         """

--- a/python/tk_framework_desktopserver/errors.py
+++ b/python/tk_framework_desktopserver/errors.py
@@ -13,21 +13,21 @@ All custom exceptions that the browser integration can emit are here.
 """
 
 
-class BrowserIntegration(Exception):
+class BrowserIntegrationError(Exception):
     """
     Base class for all browser integration errors.
     """
     pass
 
 
-class MissingCertificate(BrowserIntegration):
+class MissingCertificateError(BrowserIntegrationError):
     """
     Exception thrown when a certificate file is missing.
     """
     pass
 
 
-class PortBusy(BrowserIntegration):
+class PortBusyError(BrowserIntegrationError):
     """
     Exception thrown when the TCP port is busy.
     """

--- a/python/tk_framework_desktopserver/errors.py
+++ b/python/tk_framework_desktopserver/errors.py
@@ -22,13 +22,21 @@ class BrowserIntegrationError(Exception):
 
 class MissingCertificateError(BrowserIntegrationError):
     """
-    Exception thrown when a certificate file is missing.
+    Exception raised when a certificate file is missing.
     """
     pass
 
 
 class PortBusyError(BrowserIntegrationError):
     """
-    Exception thrown when the TCP port is busy.
+    Exception raised when the TCP port is busy.
+    """
+    pass
+
+
+class CertificateRegistrationFailed(BrowserIntegrationError):
+    """
+    Exception raised when something goes wrong while registering or
+    unregistering a certificate.
     """
     pass

--- a/python/tk_framework_desktopserver/errors.py
+++ b/python/tk_framework_desktopserver/errors.py
@@ -9,12 +9,26 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
-All custom exceptions that the desktop integration can emit are here.
+All custom exceptions that the browser integration can emit are here.
 """
 
 
-class MissingCertificate(Exception):
+class BrowserIntegration(Exception):
+    """
+    Base class for all browser integration errors.
+    """
+    pass
+
+
+class MissingCertificate(BrowserIntegration):
     """
     Exception thrown when a certificate file is missing.
+    """
+    pass
+
+
+class PortBusy(BrowserIntegration):
+    """
+    Exception thrown when the TCP port is busy.
     """
     pass

--- a/python/tk_framework_desktopserver/server.py
+++ b/python/tk_framework_desktopserver/server.py
@@ -19,7 +19,7 @@ from twisted.python import log
 
 from autobahn.twisted.websocket import WebSocketServerFactory, listenWS
 
-from .errors import MissingCertificate, PortBusy
+from .errors import MissingCertificateError, PortBusyError
 
 
 class Server:
@@ -58,7 +58,7 @@ class Server:
         :raises Exception: Thrown if the certificate file is missing.
         """
         if not os.path.exists(certificate_path):
-            raise MissingCertificate("Missing certificate file: %s" % certificate_path)
+            raise MissingCertificateError("Missing certificate file: %s" % certificate_path)
 
     def _start_server(self):
         """
@@ -87,7 +87,7 @@ class Server:
         try:
             self.listener = listenWS(self.factory, self.context_factory)
         except error.CannotListenError, e:
-            raise PortBusy(str(e))
+            raise PortBusyError(str(e))
 
     def _start_reactor(self):
         """


### PR DESCRIPTION
- Exposing port binding errors so it can be properly handled.
- Capturing stderr to the logs when registering certificates.