### PR TITLE
For #31344, certificate generation from the command line

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -62,10 +62,6 @@ if __name__ == '__main__':
     from tk_framework_desktopserver import Server, get_logger
     from tk_framework_desktopserver import shotgun_api
 
-    logger = get_logger()
-    logger.addHandler(logging.StreamHandler())
-    logger.setLevel(logging.DEBUG)
-
     parser = optparse.OptionParser()
     parser.add_option(
         "--debug", action="store_true", default=False,
@@ -94,6 +90,14 @@ if __name__ == '__main__':
 
     if options.block:
         print "Blocking calls for %s" % ", ".join(options.block)
+
+    logger = get_logger()
+    logger.addHandler(logging.StreamHandler())
+
+    if options.debug:
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.INFO)
 
     # Make a local copy of the handle because we are about to overwrite it.
     ShotgunAPI = shotgun_api.ShotgunAPI

--- a/app/app.py
+++ b/app/app.py
@@ -10,9 +10,9 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+import os
 import sys
 import optparse
-import traceback
 
 def _parse_options():
     """
@@ -79,12 +79,7 @@ def main():
 
 
 if __name__ == '__main__':
-    """
-    Simple application for client/server development and testing.
-
-    Example usage: python app.py --debug --configuration=/path/to/my/config.ini
-    """
-    sys.path.append("../python")
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../python"))
 
     # Import settings here since it wasn't in the Python path before.
     import settings

--- a/app/app.py
+++ b/app/app.py
@@ -115,7 +115,8 @@ if __name__ == '__main__':
     server = Server(
         debug=options.debug,
         keys_path=os.environ.get("SGTK_BROWSER_INTEGRATION_CERTIFICATE", "../resources/keys"),
-        port=os.environ.get("SGTK_BROWSER_INTEGRATION_PORT", 9000)
+        port=os.environ.get("SGTK_BROWSER_INTEGRATION_PORT", 9000),
+        whitelist=os.environ.get("SGTK_BROWSER_INTEGRATION_WHITELIST")
     )
     server.start()
 

--- a/app/app.py
+++ b/app/app.py
@@ -12,7 +12,7 @@
 
 import sys
 import optparse
-
+import traceback
 
 def _parse_options():
     """
@@ -50,14 +50,21 @@ def main():
     app_logger.info("Starting server with the following configuration:")
     app_settings.dump(app_logger)
 
-    # Start the server
-    server = Server(
-        debug=app_settings.debug,
-        keys_path=app_settings.certificate_folder,
-        port=app_settings.port,
-        whitelist=app_settings.whitelist
-    )
-    server.start()
+    try:
+        # Start the server
+        server = Server(
+            debug=app_settings.debug,
+            keys_path=app_settings.certificate_folder,
+            port=app_settings.port,
+            whitelist=app_settings.whitelist
+        )
+        server.start()
+    except BrowserIntegrationError, e:
+        if options.debug:
+            app_logger.exception("There was an error while running the browser integration.")
+        else:
+            app_logger.error(e)
+        return
 
     # Enables CTRL-C to kill this process even tough Qt doesn't know how to play nice with Python.
     # As per this stack overflow comment
@@ -84,7 +91,4 @@ if __name__ == '__main__':
     import logger
 
     from tk_framework_desktopserver import Server, BrowserIntegrationError
-    try:
-        main()
-    except BrowserIntegrationError, e:
-        print str(e)
+    main()

--- a/app/app.py
+++ b/app/app.py
@@ -14,6 +14,7 @@ import sys
 import os
 import optparse
 import itertools
+import logging
 
 
 def _tokenize_args(args):
@@ -58,8 +59,12 @@ if __name__ == '__main__':
     """
     sys.path.append("../python")
 
-    from tk_framework_desktopserver import Server
+    from tk_framework_desktopserver import Server, get_logger
     from tk_framework_desktopserver import shotgun_api
+
+    logger = get_logger()
+    logger.addHandler(logging.StreamHandler())
+    logger.setLevel(logging.DEBUG)
 
     parser = optparse.OptionParser()
     parser.add_option(
@@ -109,8 +114,8 @@ if __name__ == '__main__':
 
     server = Server(
         debug=options.debug,
-        keys_path=os.environ.get("TANK_DESKTOP_INTEGRATION_CERTIFICATE", "../resources/keys"),
-        port=os.environ.get("TANK_DESKTOP_INTEGRATION_PORT", 9000)
+        keys_path=os.environ.get("TANK_BROWSER_INTEGRATION_CERTIFICATE", "../resources/keys"),
+        port=os.environ.get("TANK_BROWSER_INTEGRATION_PORT", 9000)
     )
     server.start()
 

--- a/app/app.py
+++ b/app/app.py
@@ -43,7 +43,7 @@ def main():
     # Configure the app.
     options = _parse_options()
     # Create the logger and dump the settings.
-    app_logger = logger.configure_logging(options.debug)
+    app_logger = logger.get_logger(options.debug)
 
     # Read the settings and print them out.
     app_settings = settings.get_settings(options.configuration)

--- a/app/app.py
+++ b/app/app.py
@@ -83,5 +83,8 @@ if __name__ == '__main__':
     import settings
     import logger
 
-    from tk_framework_desktopserver import Server
-    main()
+    from tk_framework_desktopserver import Server, BrowserIntegrationError
+    try:
+        main()
+    except BrowserIntegrationError, e:
+        print str(e)

--- a/app/app.py
+++ b/app/app.py
@@ -114,8 +114,8 @@ if __name__ == '__main__':
 
     server = Server(
         debug=options.debug,
-        keys_path=os.environ.get("TANK_BROWSER_INTEGRATION_CERTIFICATE", "../resources/keys"),
-        port=os.environ.get("TANK_BROWSER_INTEGRATION_PORT", 9000)
+        keys_path=os.environ.get("SGTK_BROWSER_INTEGRATION_CERTIFICATE", "../resources/keys"),
+        port=os.environ.get("SGTK_BROWSER_INTEGRATION_PORT", 9000)
     )
     server.start()
 

--- a/app/app.py
+++ b/app/app.py
@@ -11,116 +11,51 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import sys
-import os
 import optparse
-import itertools
-import logging
 
 
-def _tokenize_args(args):
+def _parse_options():
     """
-    Tokenize the strings assigned to each argument to split them by commas so that we
-    can use comma separated strings for arguments.
+    Parses the command line for options.
 
-    :param args: Array of strings of each command line argument
-
-    :returns: A flat list of individual strings, without commas.
+    :returns An OptionParser with attributes debug and configuration.
     """
-    return list(itertools.chain(
-        *[arg.split(",") for arg in args]
-    ))
-
-
-if __name__ == '__main__':
-    """
-    Simple application for client/server development and testing.
-
-    Example usage: python app.py --debug
-
-    Server TODO:
-        - Test on all Platforms
-            - Dependencies:
-                [cryptography, cffi, six, pycparser]
-                [service-identity, pyasn1, pyasn1-modules, pyopens, sl, characteristic]   --> service_identity for test_client only?
-
-            - General issues with test client
-                - pip install service-identity
-            - Linux issues
-                For cffi:
-                    yum install libffi-devel
-                    yum install python-devel
-                    yum install openssl-devel
-                    pip install cffi
-                - When do we actually need both files/folder selection?
-        - uft-8 unit testing internationalization
-            - Internationalization works fine, except for this case: /Users/rivestm/tmp 普通话/ 國語/ 華語.txt, were filename is
-              'tmp 普通话/ 國語/ 華語.txt'. The '/' should be encoded by the client differently, and possibly decoded
-              differently on the server too.
-    """
-    sys.path.append("../python")
-
-    from tk_framework_desktopserver import Server, get_logger
-    from tk_framework_desktopserver import shotgun_api
-
     parser = optparse.OptionParser()
     parser.add_option(
         "--debug", action="store_true", default=False,
         help="prints debugging message from the server on the console"
     )
     parser.add_option(
-        "--local-server", action="store_true", default=False,
-        help="also runs the local server on port 8080 to mock calls from the browser."
-    )
-    parser.add_option(
-        "--fake-errors", action="append", default=[],
-        help="list of server calls to fake an error on"
-    )
-    parser.add_option(
-        "--block", action="append", default=[],
-        help="list of server calls that will block until ENTER is pressed."
+        "-c", "--configuration", action="store", default=None,
+        help="location of the configuration file"
     )
 
     options, _ = parser.parse_args()
 
-    options.fake_errors = _tokenize_args(options.fake_errors)
-    options.block = _tokenize_args(options.block)
+    return options
 
-    if options.fake_errors:
-        print "Faking errors for %s" % ", ".join(options.fake_errors)
 
-    if options.block:
-        print "Blocking calls for %s" % ", ".join(options.block)
+def main():
+    """
+    Main.
+    """
 
-    logger = get_logger()
-    logger.addHandler(logging.StreamHandler())
+    # Configure the app.
+    options = _parse_options()
+    # Create the logger and dump the settings.
+    app_logger = logger.configure_logging(options.debug)
 
-    if options.debug:
-        logger.setLevel(logging.DEBUG)
-    else:
-        logger.setLevel(logging.INFO)
+    # Read the settings and print them out.
+    app_settings = settings.get_settings(options.configuration)
+    app_logger.info("Starting server with the following configuration:")
+    app_settings.dump(app_logger)
 
-    # Make a local copy of the handle because we are about to overwrite it.
-    ShotgunAPI = shotgun_api.ShotgunAPI
-
-    class ShotgunAPIProxy(object):
-        def __init__(self, *args, **kwargs):
-            self._shotgun_api = ShotgunAPI(*args, **kwargs)
-
-        def __getattr__(self, name):
-            if name in options.fake_errors:
-                raise Exception("Fake error for '%s'." % name)
-            elif name in options.block:
-                raw_input("Blocking %s. Press ENTER to unblock." % name)
-                print "Unblocked"
-            return getattr(self._shotgun_api, name)
-
-    shotgun_api.ShotgunAPI = ShotgunAPIProxy
-
+    # Start the server
     server = Server(
-        debug=options.debug,
-        keys_path=os.environ.get("SGTK_BROWSER_INTEGRATION_CERTIFICATE", "../resources/keys"),
-        port=os.environ.get("SGTK_BROWSER_INTEGRATION_PORT", 9000),
-        whitelist=os.environ.get("SGTK_BROWSER_INTEGRATION_WHITELIST")
+        debug=app_settings.debug,
+        keys_path=app_settings.certificate_folder,
+        port=app_settings.port,
+        whitelist=app_settings.whitelist
     )
     server.start()
 
@@ -129,7 +64,24 @@ if __name__ == '__main__':
     import signal
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
+    # Start the main Qt event loop.
     from PySide import QtGui
     app = QtGui.QApplication(sys.argv)
     app.setQuitOnLastWindowClosed(False)
     app.exec_()
+
+
+if __name__ == '__main__':
+    """
+    Simple application for client/server development and testing.
+
+    Example usage: python app.py --debug --configuration=/path/to/my/config.ini
+    """
+    sys.path.append("../python")
+
+    # Import settings here since it wasn't in the Python path before.
+    import settings
+    import logger
+
+    from tk_framework_desktopserver import Server
+    main()

--- a/app/certificates.py
+++ b/app/certificates.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import sys
+import os
+import logging
+import optparse
+
+
+def __get_certificate_prompt(keychain_name, action):
+    """
+    Generates the text to use when alerting the user that we need to register the certificate.
+
+    :param keychain_name: Name of the keychain-like entity for a particular OS.
+    :param action: Description of what the user will need to do when the OS prompts the user.
+
+    :returns: String containing an error message formatted
+    """
+    return ("This script needs to install a security certificate into your %s before "
+            "it can turn on the browser integration.\n"
+            "%s.\nPress ENTER to continue." % (keychain_name, action))
+
+
+def __warn_for_prompt():
+    """
+    Warn the user he will be prompted.
+    """
+    if sys.platform == "darwin":
+        raw_input(
+            __get_certificate_prompt(
+                "keychain",
+                "You will be prompted to enter your username and password by MacOS's keychain "
+                "manager in order to proceed with the update."
+            )
+        )
+    elif sys.platform == "win32":
+        raw_input(
+            __get_certificate_prompt(
+                "Windows certificate store",
+                "Windows will now prompt you to accept an update to your certificate store."
+            )
+        )
+    # On Linux there's no need to prompt. It's all silent.
+
+
+def __remove_certificate(certificate_folder):
+    """
+    Ensures that the certificates are created and registered. If something is amiss, then the
+    configuration is fixed.
+
+    :param certificate_folder: Folder where the certificates are stored.
+    """
+
+    cert_handler = tk_framework_desktopserver.get_certificate_handler(certificate_folder)
+
+    # Check if there is a certificate registered with the keychain.
+    if cert_handler.is_registered():
+        logger.debug("Removing certificate from database.")
+        __warn_for_prompt()
+        cert_handler.unregister()
+        logger.info("The certificate is now unegistered.")
+    else:
+        logger.info("No certificate was registered.")
+
+    # Make sure the certificates exist.
+    if cert_handler.exists():
+        logger.debug("Certificate was found on disk at %s." % certificate_folder)
+        cert_handler.remove_files()
+        logger.info("The certificate was removed at %s." % certificate_folder)
+    else:
+        logger.info("No certificate was found on disk at %s." % certificate_folder)
+
+
+def __create_certificate(certificate_folder):
+    """
+    Ensures that the certificates are created and registered. If something is amiss, then the
+    configuration is fixed.
+
+    :param certificate_folder: Folder where the certificates are stored.
+    """
+
+    cert_handler = tk_framework_desktopserver.get_certificate_handler(certificate_folder)
+
+    # We only warn once.
+    warned = False
+    # Make sure the certificates exist.
+    if not cert_handler.exists():
+        logger.debug("Certificate doesn't exist on disk.")
+        # Start by unregistering certificates from the keychains, this can happen if the user
+        # wiped his certificates folder.
+        if cert_handler.is_registered():
+            # Warn once.
+            __warn_for_prompt()
+            logger.debug("Unregistering dangling certificate from database...")
+            warned = True
+            cert_handler.unregister()
+            logger.debug("Done.")
+        # Create the certificate files
+        logger.debug("About to create the certificates...")
+        cert_handler.create()
+        logger.info("Certificate created at %s." % certificate_folder)
+    else:
+        logger.info("Certificate already exist on disk at %s." % certificate_folder)
+
+    # Check if the certificates are registered with the keychain.
+    if not cert_handler.is_registered():
+        logger.debug("Certificate is not currently registered in the keychain.")
+        # Only if we've never been warned before.
+        if not warned:
+            __warn_for_prompt()
+        cert_handler.register()
+        logger.info("Certificate is now registered .")
+    else:
+        logger.info("Certificate is already registered.")
+
+
+if __name__ == '__main__':
+    # Add the modules files to PYTHOHPATH
+    sys.path.insert(0, "../python")
+    import tk_framework_desktopserver
+
+    # Make sure logger output goes to stdout
+    logger = tk_framework_desktopserver.get_logger()
+    logger.addHandler(logging.StreamHandler())
+
+    parser = optparse.OptionParser()
+    parser.add_option(
+        "--debug", action="store_true", default=False,
+        help="prints debugging message from the certificate generation."
+    )
+    parser.add_option(
+        "--remove", action="store_true", default=False,
+        help="prints debugging message from the certificate generation."
+    )
+
+    options, _ = parser.parse_args()
+
+    if options.debug is True:
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.INFO)
+
+    folder = os.environ.get("TANK_BROWSER_INTEGRATION_CERTIFICATE", "../resources/keys")
+    folder = os.path.expanduser(folder)
+    folder = os.path.abspath(folder)
+    folder = os.path.normpath(folder)
+
+    if options.remove:
+        __remove_certificate(folder)
+    else:
+        __create_certificate(folder)

--- a/app/certificates.py
+++ b/app/certificates.py
@@ -9,7 +9,6 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import sys
-import logging
 import optparse
 
 
@@ -57,7 +56,7 @@ def __remove_certificate(certificate_folder, logger):
     :param certificate_folder: Folder where the certificates are stored.
     """
 
-    cert_handler = tk_framework_desktopserver.get_certificate_handler(certificate_folder)
+    cert_handler = get_certificate_handler(certificate_folder)
 
     # Removes the certificate from the OS/browser certificate database.
     if cert_handler.is_registered():
@@ -85,7 +84,7 @@ def __create_certificate(certificate_folder, logger):
     :param certificate_folder: Folder where the certificates are stored.
     """
 
-    cert_handler = tk_framework_desktopserver.get_certificate_handler(certificate_folder)
+    cert_handler = get_certificate_handler(certificate_folder)
 
     # We only warn once.
     warned = False
@@ -133,7 +132,7 @@ def _parse_options():
     )
     parser.add_option(
         "--remove", action="store_true", default=False,
-        help="prints debugging message from the certificate generation"
+        help="removes the certificate from disk and from the certificate database"
     )
     parser.add_option(
         "-c", "--configuration", action="store", default=None,
@@ -151,20 +150,23 @@ def main():
     # Configure the app.
     options = _parse_options()
     # Create the logger
-    logger = logger.configure_logging(options.debug)
+    app_logger = logger.configure_logging(options.debug)
 
     app_settings = settings.get_settings(options.configuration)
 
     if options.remove:
-        __remove_certificate(app_settings.certificate_folder, logger)
+        __remove_certificate(app_settings.certificate_folder, app_logger)
     else:
-        __create_certificate(app_settings.certificate_folder, logger)
+        __create_certificate(app_settings.certificate_folder, app_logger)
 
 
 if __name__ == '__main__':
     # Add the modules files to PYTHOHPATH
     sys.path.insert(0, "../python")
-    import tk_framework_desktopserver
+    from tk_framework_desktopserver import get_certificate_handler, BrowserIntegrationError
     import settings
     import logger
-    main()
+    try:
+        main()
+    except BrowserIntegrationError, e:
+        print str(e)

--- a/app/certificates.py
+++ b/app/certificates.py
@@ -119,11 +119,11 @@ def __create_certificate(certificate_folder, logger):
         logger.info("Certificate is already registered.")
 
 
-def _parse_options():
+def __parse_options():
     """
     Parses the command line for options.
 
-    :returns An OptionParser with attributes debug and remove.
+    :returns An OptionParser with attributes debug, remove and configuration.
     """
     parser = optparse.OptionParser()
     parser.add_option(
@@ -148,9 +148,9 @@ def main():
     Main.
     """
     # Configure the app.
-    options = _parse_options()
+    options = __parse_options()
     # Create the logger
-    app_logger = logger.configure_logging(options.debug)
+    app_logger = logger.get_logger(options.debug)
 
     app_settings = settings.get_settings(options.configuration)
 

--- a/app/certificates.py
+++ b/app/certificates.py
@@ -8,9 +8,10 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+import os
 import sys
 import optparse
-import traceback
+
 
 def __get_certificate_prompt(keychain_name, action):
     """
@@ -174,7 +175,7 @@ def main():
 
 if __name__ == '__main__':
     # Add the modules files to PYTHOHPATH
-    sys.path.insert(0, "../python")
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../python"))
     from tk_framework_desktopserver import get_certificate_handler, BrowserIntegrationError
     import settings
     import logger

--- a/app/certificates.py
+++ b/app/certificates.py
@@ -147,7 +147,7 @@ if __name__ == '__main__':
     else:
         logger.setLevel(logging.INFO)
 
-    folder = os.environ.get("TANK_BROWSER_INTEGRATION_CERTIFICATE", "../resources/keys")
+    folder = os.environ.get("SGTK_BROWSER_INTEGRATION_CERTIFICATE", "../resources/keys")
     folder = os.path.expanduser(folder)
     folder = os.path.abspath(folder)
     folder = os.path.normpath(folder)

--- a/app/config.ini.example
+++ b/app/config.ini.example
@@ -14,7 +14,9 @@ certificate_folder=/path/to/the/certificate/folder
 debug=0
 
 # Port to listen for requests coming from the browser. If not specified,
-# defaults to 9000.
+# defaults to 9000. Note that you will need to contact support at
+# support@shotgunsoftware.com in order to have your site communicate on a custom
+# port.
 #
 port=9000
 

--- a/app/config.ini.example
+++ b/app/config.ini.example
@@ -1,0 +1,24 @@
+# This is the browser integration settings section
+#
+
+[BrowserIntegration]
+
+# Location where the certificate will be stored. If not specified, defaults to
+# ../resources/keys.
+#
+certificate_folder=/path/to/the/certificate/folder
+
+# If set to 1, Twisted messages will be printed. If not specified, defaults to
+# 0. Warning, this produces a lot of output.
+#
+debug=0
+
+# Port to listen for requests coming from the browser. If not specified,
+# defaults to 9000.
+#
+port=9000
+
+# List of clients whitelisted to access this server. Use this when you have a
+# local server. If not specified, defaults to *.shotgunstudio.com.
+#
+whitelist=*.shotgunstudio.com

--- a/app/logger.py
+++ b/app/logger.py
@@ -10,10 +10,10 @@
 
 import logging
 
-from tk_framework_desktopserver import get_logger
+import tk_framework_desktopserver
 
 
-def configure_logging(debug):
+def get_logger(debug):
     """
     Configures the logging for the app.
 
@@ -22,7 +22,7 @@ def configure_logging(debug):
     :returns: The root logger for the app.
     """
     # Make sure logger output goes to stdout
-    logger = get_logger()
+    logger = tk_framework_desktopserver.get_logger()
     handler = logging.StreamHandler()
     formatter = logging.Formatter('%(asctime)s [%(name)s.%(levelname)s] %(message)s')
     handler.setFormatter(formatter)

--- a/app/logger.py
+++ b/app/logger.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import logging
+
+from tk_framework_desktopserver import get_logger
+
+
+def configure_logging(debug):
+    """
+    Configures the logging for the app.
+
+    :param debug: True if debug is needed, False otherwise.
+
+    :returns: The root logger for the app.
+    """
+    # Make sure logger output goes to stdout
+    logger = get_logger()
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter('%(asctime)s [%(name)s.%(levelname)s] %(message)s')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
+    if debug:
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.INFO)
+
+    return logger

--- a/app/settings.py
+++ b/app/settings.py
@@ -34,7 +34,7 @@ def get_settings(configuration):
     if configuration is not None:
         location = configuration
     # Then check the environment variable.
-    elif "SGTK_BROWSER_CONFIG_LOCATION" in os.environ:
+    elif "SGTK_BROWSER_INTEGRATION_CONFIG_LOCATION" in os.environ:
         location = os.environ["SGTK_BROWSER_INTEGRATION_CONFIG_LOCATION"]
     else:
         # Nothing has been found!

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+
+from tk_framework_desktopserver import Settings, MissingConfigurationFileError, get_logger
+
+
+def get_settings(configuration):
+    """
+    Retrieves the location of the config.ini file for the standalone apps. It will first look at the
+    command line arguments. If the file specified on the command line doesn't exist, an error will
+    be thrown. Then the SGTK_BROWSER_INTEGRATION_CONFIG_LOCATION environment variable will be evaluated.
+    If the value points to a non existing path, an error will be thrown. Then the config.ini
+    file in the current folder will be parsed. If the file is missing, a settings object with only
+    default settings will be returned.
+
+    :param configuration: Path to the configuration path. Can be None.
+
+    :returns: The location where to read the configuration file from.
+
+    :raises MissingConfigurationFileError: Raised when the user supplied configuration file
+        doesn't exist on disk.
+    """
+
+    # First check the command line.
+    if configuration is not None:
+        location = configuration
+    # Then check the environment variable.
+    elif "SGTK_BROWSER_CONFIG_LOCATION" in os.environ:
+        location = os.environ["SGTK_BROWSER_INTEGRATION_CONFIG_LOCATION"]
+    else:
+        # Nothing has been found!
+        location = None
+
+    # If the user specified a location and it doesn't exist, raise an error.
+    if location and not os.path.exists(location):
+        raise MissingConfigurationFileError(location)
+
+    # Create an absolute path to the file.
+    app_dir = os.path.abspath(os.path.dirname(__file__))
+
+    # If no location was specified, simply read from the local directory.
+    if location is None:
+        location = os.path.join(app_dir, "config.ini")
+
+    get_logger("settings").debug("Using configuration file at '%s'" % location)
+    return Settings(
+        location,
+        # Go back up a folder to retrieve the root of the package and drill
+        # into the resource files to look for the keys
+        os.path.join(
+            os.path.dirname(app_dir),
+            "resources/keys"
+        )
+    )

--- a/python/tk_framework_desktopserver/__init__.py
+++ b/python/tk_framework_desktopserver/__init__.py
@@ -23,7 +23,8 @@ elif os.name == "posix":
     sys.path.append(os.path.join(distributions_path, "linux"))
 
 from .server import Server
+from .settings import Settings
 from .process_manager import ProcessManager
 from .certificates import get_certificate_handler
 from .logger import get_logger
-from .errors import MissingCertificateError, PortBusyError
+from .errors import MissingCertificateError, PortBusyError, MissingConfigurationFileError

--- a/python/tk_framework_desktopserver/__init__.py
+++ b/python/tk_framework_desktopserver/__init__.py
@@ -27,4 +27,4 @@ from .settings import Settings
 from .process_manager import ProcessManager
 from .certificates import get_certificate_handler
 from .logger import get_logger
-from .errors import MissingCertificateError, PortBusyError, MissingConfigurationFileError
+from .errors import MissingCertificateError, PortBusyError, MissingConfigurationFileError, BrowserIntegrationError

--- a/python/tk_framework_desktopserver/certificates.py
+++ b/python/tk_framework_desktopserver/certificates.py
@@ -101,7 +101,7 @@ class _CertificateHandler(object):
         p = subprocess.Popen(cmd, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, shell=True)
         stdout, _ = p.communicate()
         if p.returncode != 0:
-            self._logger.debug("Unexpected output:\n%s" % stdout)
+            self._logger.error("Unexpected output:\n%s" % stdout)
             raise CertificateRegistrationError("There was a problem %s." % ctx)
 
     def is_registered(self):
@@ -121,7 +121,7 @@ class _CertificateHandler(object):
         )
         stdout, _ = p.communicate()
         if p.returncode != 0:
-            self._logger.debug("Unexpected output:\n%s" % stdout)
+            self._logger.error("Unexpected output:\n%s" % stdout)
             raise CertificateRegistrationError(
                 "There was a problem validating if a certificate was installed."
             )

--- a/python/tk_framework_desktopserver/certificates.py
+++ b/python/tk_framework_desktopserver/certificates.py
@@ -36,6 +36,13 @@ class _CertificateHandler(object):
         """
         return os.path.exists(self._cert_path) and os.path.exists(self._key_path)
 
+    def remove_files(self):
+        """
+        Removes the files from the
+        """
+        os.unlink(self._cert_path)
+        os.unlink(self._key_path)
+
     def create(self):
         """
         Creates a self-signed certificate.
@@ -97,7 +104,7 @@ class _CertificateHandler(object):
             subprocess.check_call(cmd, stderr=subprocess.STDOUT, shell=True)
         except subprocess.CalledProcessError, e:
             self._logger.exception("There was a problem %s" % ctx)
-            self._logger.info("Output:\n%s" % e.output)
+            self._logger.debug("Output:\n%s" % e.output)
             raise
 
     def is_registered(self):
@@ -113,7 +120,7 @@ class _CertificateHandler(object):
             return "Shotgun" in subprocess.check_output(self._get_is_registered_cmd(), stderr=subprocess.STDOUT, shell=True)
         except subprocess.CalledProcessError, e:
             self._logger.exception("There was a problem validating if a certificate was installed.")
-            self._logger.info("Output:\n%s" % e.output)
+            self._logger.debug("Output:\n%s" % e.output)
             raise
 
     def unregister(self):

--- a/python/tk_framework_desktopserver/certificates.py
+++ b/python/tk_framework_desktopserver/certificates.py
@@ -12,8 +12,8 @@ from __future__ import with_statement
 import os
 import sys
 import subprocess
-import logging
-from .errors import CertificateRegistrationFailed
+from .logger import get_logger
+from .errors import CertificateRegistrationError
 
 from OpenSSL import crypto
 
@@ -27,7 +27,7 @@ class _CertificateHandler(object):
         """
         Constructor.
         """
-        self._logger = logging.getLogger("tk-framework-desktopserver.certificate")
+        self._logger = get_logger("certificates")
         self._cert_path = os.path.join(certificate_folder, "server.crt")
         self._key_path = os.path.join(certificate_folder, "server.key")
 
@@ -90,23 +90,19 @@ class _CertificateHandler(object):
 
     def _check_call(self, ctx, cmd):
         """
-        Runs a process and logs it's output if the return code was not 0.
+        Runs a process and raises an exception if the return code is not 0.
 
         :param ctx: string identifying the goal of the command. Will complete this sentence:
-            "There was a problem %s" %% ctx
+            "There was a problem %s." %% ctx
         :param cmd: Command to run.
 
-        :returns: True if the process returns 0, False otherwise.
+        :raises CertificateRegistrationError: Raised when the subprocess doesn't return 0.
         """
-        try:
-            # Sometimes the is_registered_cmd will output Shotgun Software and sometimes it will
-            # only output the pretty name Shotgun Desktop Integration, so searching for Shotgun is 
-            # good enough.
-            subprocess.check_call(cmd, stderr=subprocess.STDOUT, shell=True)
-        except subprocess.CalledProcessError, e:
-            self._logger.exception("There was a problem %s" % ctx)
-            self._logger.debug("Output:\n%s" % e.output)
-            raise CertificateRegistrationFailed("There was a problem %s" % ctx)
+        p = subprocess.Popen(cmd, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, shell=True)
+        stdout, _ = p.communicate()
+        if p.returncode != 0:
+            self._logger.debug("Unexpected output:\n%s" % stdout)
+            raise CertificateRegistrationError("There was a problem %s." % ctx)
 
     def is_registered(self):
         """
@@ -114,15 +110,22 @@ class _CertificateHandler(object):
 
         :returns: True if the certificate is registered, False otherwise.
         """
-        try:
-            # Sometimes the is_registered_cmd will output Shotgun Software and sometimes it will
-            # only output the pretty name Shotgun Desktop Integration, so searching for Shotgun is
-            # good enough.
-            return "Shotgun" in subprocess.check_output(self._get_is_registered_cmd(), stderr=subprocess.STDOUT, shell=True)
-        except subprocess.CalledProcessError, e:
-            self._logger.exception("There was a problem validating if a certificate was installed.")
-            self._logger.debug("Output:\n%s" % e.output)
-            raise CertificateRegistrationFailed("There was a problem validating if a certificate was installed.")
+        # Sometimes the is_registered_cmd will output Shotgun Software and sometimes it will
+        # only output the pretty name Shotgun Desktop Integration, so searching for Shotgun is
+        # good enough.
+        p = subprocess.Popen(
+            self._get_is_registered_cmd(),
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+            shell=True
+        )
+        stdout, _ = p.communicate()
+        if p.returncode != 0:
+            self._logger.debug("Unexpected output:\n%s" % stdout)
+            raise CertificateRegistrationError(
+                "There was a problem validating if a certificate was installed.", stdout
+            )
+        return "Shotgun" in stdout
 
     def unregister(self):
         """
@@ -203,7 +206,7 @@ class _LinuxCertificateHandler(_CertificateHandler):
         :returns: True on success, False on failure.
         """
         return self._check_call(
-            "registering certificate",
+            "registering the certificate",
             "certutil -A -d %s -i \"%s\" -n %s -t \"TC,C,c\"" % (
                 self._PKI_DB_PATH, self._cert_path, self._CERTIFICATE_PRETTY_NAME
             )
@@ -216,7 +219,7 @@ class _LinuxCertificateHandler(_CertificateHandler):
         :returns: True on success, False on failure.
         """
         return self._check_call(
-            "unregistering certificate",
+            "unregistering the certificate",
             "certutil -D -d %s -n %s" % (self._PKI_DB_PATH, self._CERTIFICATE_PRETTY_NAME)
         )
 
@@ -241,7 +244,7 @@ class _WindowsCertificateHandler(_CertificateHandler):
         :returns: True on success, False on failure.
         """
         return self._check_call(
-            "registering certificate",
+            "registering the certificate",
             ("certutil", "-user", "-addstore", "root", self._cert_path.replace("/", "\\"))
         )
 
@@ -255,7 +258,7 @@ class _WindowsCertificateHandler(_CertificateHandler):
         # have the same name. Maybe we should write the sha to disk and delete using that as
         # a query (certutil -user -delstore root sha1).
         return self._check_call(
-            "unregistering certificate",
+            "unregistering the certificate",
             ("certutil", "-user", "-delstore", "root", "localhost")
         )
 
@@ -276,7 +279,7 @@ class _MacCertificateHandler(_CertificateHandler):
         # is to reboot. Note that doing that trusting the certificate via the UI exposes the same
         # issue.
         return self._check_call(
-            "registering certificate",
+            "registering the certificate",
             "security add-trusted-cert -k ~/Library/Keychains/login.keychain -r trustRoot  \"%s\"" %
             self._cert_path
         )
@@ -302,7 +305,7 @@ class _MacCertificateHandler(_CertificateHandler):
         # a query (security delete-certificate -Z sha1 -t).
         if self.is_registered():
             return self._check_call(
-                "removing trusted certificate",
+                "removing the trusted certificate",
                 "security delete-certificate -c localhost -t"
             )
         else:

--- a/python/tk_framework_desktopserver/certificates.py
+++ b/python/tk_framework_desktopserver/certificates.py
@@ -123,7 +123,7 @@ class _CertificateHandler(object):
         if p.returncode != 0:
             self._logger.debug("Unexpected output:\n%s" % stdout)
             raise CertificateRegistrationError(
-                "There was a problem validating if a certificate was installed.", stdout
+                "There was a problem validating if a certificate was installed."
             )
         return "Shotgun" in stdout
 

--- a/python/tk_framework_desktopserver/errors.py
+++ b/python/tk_framework_desktopserver/errors.py
@@ -34,13 +34,12 @@ class PortBusyError(BrowserIntegrationError):
     pass
 
 
-class CertificateRegistrationFailed(BrowserIntegrationError):
+class CertificateRegistrationError(BrowserIntegrationError):
     """
     Exception raised when something goes wrong while registering or
     unregistering a certificate.
     """
     pass
-
 
 class MissingConfigurationFileError(BrowserIntegrationError):
     """

--- a/python/tk_framework_desktopserver/errors.py
+++ b/python/tk_framework_desktopserver/errors.py
@@ -32,3 +32,20 @@ class PortBusyError(BrowserIntegrationError):
     Exception thrown when the TCP port is busy.
     """
     pass
+
+
+class MissingConfigurationFileError(BrowserIntegrationError):
+    """
+    Raised when the configuration file can't be found.
+    """
+    def __init__(self, location):
+        """
+        Constructor.
+
+        :params location: Path to the missing configuration file.
+        """
+        BrowserIntegrationError.__init__(
+            self,
+            "The configuration file at '%s' could not be found!" % location
+        )
+

--- a/python/tk_framework_desktopserver/errors.py
+++ b/python/tk_framework_desktopserver/errors.py
@@ -41,6 +41,7 @@ class CertificateRegistrationError(BrowserIntegrationError):
     """
     pass
 
+
 class MissingConfigurationFileError(BrowserIntegrationError):
     """
     Raised when the configuration file can't be found.

--- a/python/tk_framework_desktopserver/logger.py
+++ b/python/tk_framework_desktopserver/logger.py
@@ -15,8 +15,6 @@ def get_logger(child_logger=None):
     """
     Returns the logger used by this framework.
     """
-    # FIXME: We should forward the logging from twisted into our own. Read more about
-    # it here: http://twistedmatrix.com/documents/12.0.0/core/howto/logging.html#auto3
     if not child_logger:
         return logging.getLogger("tk-framework-desktopserver")
     else:

--- a/python/tk_framework_desktopserver/settings.py
+++ b/python/tk_framework_desktopserver/settings.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+import ConfigParser
+
+from . import logger
+
+logger = logger.get_logger("settings")
+
+
+class Settings(object):
+    """
+    Reads the optionally configured configuration file present in the Desktop
+    installer package. This file is in the root of the installed application folder on
+    Linux and Windows and in Contents/Resources on MacOSX.
+
+    The configuration file should have the following format:
+    [BrowserIntegration]
+    port=9000
+    debug=1
+    whitelist=*.shotgunstudio.com
+    certificate_folder=/path/to/the/certificate
+    """
+
+    _BROWSER_INTEGRATION = "BrowserIntegration"
+
+    def __init__(self, location, default_certificate_folder):
+        """
+        Constructor.
+
+        If the configuration file doesn't not exist, the configuration
+        object will return the default values.
+
+        :param location: Path to the configuration file.
+        :param default_certificate_folder: Default location for the certificate file. This value
+            is overridable for each app that can use this settings object.
+        """
+        self._config = self._load_config(location)
+        self._default_certificate_folder = default_certificate_folder
+
+    def _load_config(self, path):
+        """
+        Loads the configuration at a given location and returns it.
+
+        :param path: Path to the configuration to load.
+
+        :returns: A ConfigParser instance with the contents from the configuration file.
+        """
+        config = ConfigParser.SafeConfigParser()
+        if os.path.exists(path):
+            config.read(path)
+        return config
+
+    @property
+    def port(self):
+        """
+        :returns: The port to listen on for incoming websocket requests.
+        """
+        return self._get_value(self._BROWSER_INTEGRATION, "port", int, 9000)
+
+    @property
+    def debug(self):
+        """
+        :returns: True if the server should run in debug mode. False otherwise.
+        """
+        # Any non empty string is True, so convert it to int, which will accept 0 or 1 and then
+        # we'll cast the return value to a boolean.
+        return bool(self._get_value(self._BROWSER_INTEGRATION, "debug", int, False))
+
+    @property
+    def whitelist(self):
+        """
+        :returns: The list of clients that can connect to the server.
+        """
+        return self._get_value(self._BROWSER_INTEGRATION, "whitelist", default="*.shotgunstudio.com")
+
+    @property
+    def certificate_folder(self):
+        """
+        :returns: Path to the certificate location.
+        """
+        return self._get_value(
+            self._BROWSER_INTEGRATION, "certificate_folder", default=self._default_certificate_folder
+        )
+
+    def dump(self, logger):
+        """
+        Dumps all the settings into the logger.
+        """
+        logger.info("Certificate folder: %s" % self.certificate_folder)
+        logger.info("Debug: %s" % self.debug)
+        logger.info("Port: %d" % self.port)
+        logger.info("Whitelist: %s" % self.whitelist)
+
+    def _get_value(self, section, key, type_cast=str, default=None):
+        """
+        Retrieves a value from the config.ini file. If the value is not set, returns the default.
+        Since all values are strings inside the file, you can optionally cast the data to another type.
+
+        :param section: Section (name between brackets) of the setting.
+        :param key: Name of the setting within a section.
+        ;param type_cast: Casts the value to the passed in type. Defaults to str.
+        :param default: If the value is not found, returns this default value. Defauts to None.
+
+        :returns: The appropriately type casted value if the value is found, default otherwise.
+        """
+        if not self._config.has_section(section):
+            return default
+        elif not self._config.has_option(section, key):
+            return default
+        else:
+            return type_cast(self._resolve_value(section, key))
+
+    def _resolve_value(self, section, key):
+        """
+        Resolves a value in the file and translates any environment variable or ~ present.
+
+        :param section: Name of the section of the value.
+        :param key: Key of the value to retrieve for the selection section.
+
+        :returns: Value with ~ and any environment variable resolved.
+        """
+        return os.path.expandvars(
+            os.path.expanduser(
+                self._config.get(section, key)
+            )
+        )

--- a/resources/python/common/autobahn/websocket/protocol.py
+++ b/resources/python/common/autobahn/websocket/protocol.py
@@ -869,7 +869,7 @@ class WebSocketProtocol:
          else:
             ## Either reply with same code/reason, or code == NORMAL/reason=None
             if self.echoCloseCodeReason:
-               self.sendCloseFrame(code = code, reasonUtf8 = reason.encode("UTF-8"), isReply = True)
+               self.sendCloseFrame(code = code, reasonUtf8 = reasonRaw.encode("UTF-8") if reasonRaw else None, isReply = True)
             else:
                self.sendCloseFrame(code = WebSocketProtocol.CLOSE_STATUS_CODE_NORMAL, isReply = True)
 

--- a/resources/python/common/autobahn/websocket/protocol.py
+++ b/resources/python/common/autobahn/websocket/protocol.py
@@ -832,6 +832,8 @@ class WebSocketProtocol:
             if self.invalidPayload("invalid close reason (non-UTF-8 payload)"):
                return True
          self.remoteCloseReason = reasonRaw.decode('utf8')
+      else:
+         self.remoteCloseReason = None
 
       ## handle receive of close frame depending on protocol state
       ##
@@ -869,7 +871,7 @@ class WebSocketProtocol:
          else:
             ## Either reply with same code/reason, or code == NORMAL/reason=None
             if self.echoCloseCodeReason:
-               self.sendCloseFrame(code = code, reasonUtf8 = reasonRaw.encode("UTF-8") if reasonRaw else None, isReply = True)
+               self.sendCloseFrame(code = code, reasonUtf8 = self.remoteCloseReason, isReply = True)
             else:
                self.sendCloseFrame(code = WebSocketProtocol.CLOSE_STATUS_CODE_NORMAL, isReply = True)
 


### PR DESCRIPTION
Introduces a new script that allows to create the certificates from the command line.
- `python certificates.py` will create it
- `python certificates.py --remove` will remove it
- adding `--debug` will send debug level logging to the console.

Also renamed the environment variables to configure the server. They are now SGTK_BROWSER_INTEGRATION_PORT and SGTK_BROWSER_INTEGRATION_CERTIFICATE.

Also, SGTK_BROWSER_INTEGRATION_WHITELIST was introduced to change the whitelist.