### PR TITLE
For #33073, do not log sensitive information

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -14,6 +14,7 @@ import os
 import sys
 import optparse
 
+
 def _parse_options():
     """
     Parses the command line for options.
@@ -53,7 +54,7 @@ def main():
     try:
         # Start the server
         server = Server(
-            debug=app_settings.debug,
+            low_level_debug=app_settings.low_level_debug,
             keys_path=app_settings.certificate_folder,
             port=app_settings.port,
             whitelist=app_settings.whitelist

--- a/app/config.ini.example
+++ b/app/config.ini.example
@@ -17,10 +17,11 @@ certificate_folder=/path/to/your/certificate/folder
 # Linux
 # certificate_folder=~/.shotgun/desktop/config/certificates
 
-# If set to 1, Twisted messages will be printed. If not specified, defaults to
-# 0. Warning, this produces a lot of output.
-#
-debug=0
+# WARNING: This option will write sensitive information to the logs. We
+# recommend turning this on ONLY for debugging. We recommend you clear or delete
+# your logs after debugging.
+# If set to 1, low level debugging messages from the server will be logged.
+low_level_debug=0
 
 # Port to listen for requests coming from the browser. If not specified,
 # defaults to 9000. Note that you will need to contact support at

--- a/python/tk_framework_desktopserver/command.py
+++ b/python/tk_framework_desktopserver/command.py
@@ -148,7 +148,8 @@ class Command(object):
 
             ret = process.returncode
         except StandardError:
-            get_logger().exception("Error running subprocess :%s" % args)
+            # Do not log the command line, it might contain sensitive information!
+            get_logger().exception("Error running subprocess:")
 
             ret = 1
             stderr_lines = traceback.format_exc().split()

--- a/python/tk_framework_desktopserver/process_manager.py
+++ b/python/tk_framework_desktopserver/process_manager.py
@@ -152,8 +152,9 @@ class ProcessManager(object):
         has_error = return_code != 0
 
         if has_error:
-            raise Exception("{message_error}\nCommand: {command}\nReturn code: {return_code}\nOutput: {std_out}\nError: {std_err}"
-                            .format(message_error=message_error, command=args, return_code=return_code, std_out=out, std_err=err))
+            # Do not log the command line, it might contain sensitive information.
+            raise Exception("{message_error}\nReturn code: {return_code}\nOutput: {std_out}\nError: {std_err}"
+                            .format(message_error=message_error, return_code=return_code, std_out=out, std_err=err))
 
         return True
 
@@ -195,6 +196,7 @@ class ProcessManager(object):
 
             return (out, err, return_code)
         except Exception, e:
+            # call_cmd is not supposed to include sentitive information in the error message.
             raise Exception("Error executing toolkit command: " + e.message)
 
     def _add_action_output(self, actions, out, err, code):

--- a/python/tk_framework_desktopserver/process_manager.py
+++ b/python/tk_framework_desktopserver/process_manager.py
@@ -196,7 +196,8 @@ class ProcessManager(object):
 
             return (out, err, return_code)
         except Exception, e:
-            # call_cmd is not supposed to include sentitive information in the error message.
+            # call_cmd is not including sentitive information in the error message, so this won't
+            # either.
             raise Exception("Error executing toolkit command: " + e.message)
 
     def _add_action_output(self, actions, out, err, code):

--- a/python/tk_framework_desktopserver/server_protocol.py
+++ b/python/tk_framework_desktopserver/server_protocol.py
@@ -14,7 +14,6 @@ import re
 import datetime
 from urlparse import urlparse
 import OpenSSL
-import logging
 
 import shotgun_api
 from .message_host import MessageHost
@@ -60,10 +59,10 @@ class ServerProtocol(WebSocketServerProtocol):
                 self._logger.info("Certificate error!")
                 StatusServerProtocol.serverStatus = StatusServerProtocol.SSL_CERTIFICATE_INVALID
             else:
-                self._logger.info("Connection lost!")
+                self._logger.info("Connection closed.")
                 StatusServerProtocol.serverStatus = StatusServerProtocol.CONNECTION_LOST
         except Exception:
-            self._logger.exception()
+            self._logger.exception("Unexpected error while losing connection.")
             StatusServerProtocol.serverStatus = StatusServerProtocol.CONNECTION_LOST
 
     def onConnect(self, response):
@@ -82,7 +81,7 @@ class ServerProtocol(WebSocketServerProtocol):
             # response.origin: xyz.shotgunstudio.com
             domain_valid = self._is_domain_valid(response.origin)
         except:
-            self._logger.exception()
+            self._logger.exception("Unexpected error while losing connection.")
 
         if not domain_valid:
             self._logger.info("Invalid domain: %s" % response.origin)
@@ -190,8 +189,8 @@ class ServerProtocol(WebSocketServerProtocol):
         # ensure_ascii allows unicode strings.
         payload = json.dumps(data, ensure_ascii=False, default=self._json_date_handler).encode("utf8")
 
-        isBinary = False
-        self.sendMessage(payload, isBinary)
+        is_binary = False
+        self.sendMessage(payload, is_binary)
 
     def _wildcard_match(self, wildcard, match):
         """

--- a/python/tk_framework_desktopserver/server_protocol.py
+++ b/python/tk_framework_desktopserver/server_protocol.py
@@ -81,12 +81,14 @@ class ServerProtocol(WebSocketServerProtocol):
             # response.origin: xyz.shotgunstudio.com
             domain_valid = self._is_domain_valid(response.origin)
         except:
-            self._logger.exception("Unexpected error while losing connection.")
+            self._logger.exception("Unexpected error while trying to determine the originating domain.")
 
         if not domain_valid:
             self._logger.info("Invalid domain: %s" % response.origin)
             # Don't accept connection
             raise websocket.http.HttpException(403, "Domain origin was rejected by server.")
+        else:
+            self._logger.info("Connection accepted.")
 
     def onMessage(self, payload, isBinary):
         """

--- a/python/tk_framework_desktopserver/settings.py
+++ b/python/tk_framework_desktopserver/settings.py
@@ -67,13 +67,13 @@ class Settings(object):
         return self._get_value(self._BROWSER_INTEGRATION, "port", int, 9000)
 
     @property
-    def debug(self):
+    def low_level_debug(self):
         """
-        :returns: True if the server should run in debug mode. False otherwise.
+        :returns: True if the server should run in low level debugging mode. False otherwise.
         """
         # Any non empty string is True, so convert it to int, which will accept 0 or 1 and then
         # we'll cast the return value to a boolean.
-        return bool(self._get_value(self._BROWSER_INTEGRATION, "debug", int, False))
+        return bool(self._get_value(self._BROWSER_INTEGRATION, "low_level_debug", int, False))
 
     @property
     def whitelist(self):
@@ -96,7 +96,7 @@ class Settings(object):
         Dumps all the settings into the logger.
         """
         logger.info("Certificate folder: %s" % self.certificate_folder)
-        logger.info("Debug: %s" % self.debug)
+        logger.info("Low level debug: %s" % self.low_level_debug)
         logger.info("Port: %d" % self.port)
         logger.info("Whitelist: %s" % self.whitelist)
 


### PR DESCRIPTION
When Twisted is used in debug mode, message content is logged. This can pose a security risk since that information will go to a log file on the user's drive. However this feature is very handy for debugging the server, so now Twisted's logging is sent to stdout and not propagated to the parent logger when debug is set. If debug is not set, the output of Twisted is considered safe and logger messages will be propagated to the parent accordingly.

This refactoring also has the benefit that now standard Twisted logging will be logged to desktop, so we can know if there are unexpected errors inside Twisted.