### PR TITLE
For #31017, mounted volumes are missing on OSX.

### DIFF
--- a/python/tk_framework_desktopserver/sgtk_file_dialog.py
+++ b/python/tk_framework_desktopserver/sgtk_file_dialog.py
@@ -50,7 +50,7 @@ class SgtkFileDialog(QtGui.QFileDialog):
         if sys.platform == "darwin":
             sidebar_urls = self.sidebarUrls()
             if self._VOLUMES_URL not in sidebar_urls:
-                sidebar_urls.append("file:///Volumes")
+                sidebar_urls.append(self._VOLUMES_URL)
             self.setSidebarUrls(sidebar_urls)
 
         # Make the combobox editable so we can specify a path through it.

--- a/python/tk_framework_desktopserver/sgtk_file_dialog.py
+++ b/python/tk_framework_desktopserver/sgtk_file_dialog.py
@@ -22,6 +22,8 @@ class SgtkFileDialog(QtGui.QFileDialog):
     Note that it doesn't quite succeed at this in every os as some can't do both file and folder extended selection.
     """
 
+    _VOLUMES_URL = "file:///Volumes"
+
     def __init__(self, multi=False, *args, **kwargs):
         """
         Initialize file dialog.
@@ -46,11 +48,35 @@ class SgtkFileDialog(QtGui.QFileDialog):
         # FIXME: On MacOS the QFileDialog hides all hidden files. Unfortunately /Volumes is hidden.
         # As a quick hack to unblock our clients, we'll add /Volumes to the sidebar.
         if sys.platform == "darwin":
-            sidebarUrls = self.sidebarUrls()
-            sidebarUrls.append("file:///Volumes")
-            self.setSidebarUrls(sidebarUrls)
+            sidebar_urls = self.sidebarUrls()
+            if self._VOLUMES_URL not in sidebar_urls:
+                sidebar_urls.append("file:///Volumes")
+            self.setSidebarUrls(sidebar_urls)
+
+        # Make the combobox editable so we can specify a path through it.
+        c = self.findChild(QtGui.QComboBox, "lookInCombo")
+        c.setEditable(True)
+        # Search for the line edit widget, it has no name so scan for it.
+        line_edits = filter(lambda x: isinstance(x, QtGui.QLineEdit), c.children())
+        if len(line_edits) != 1:
+            raise Exception("Expected to find a line edit widget.")
+        self._path_editor = line_edits[0]
+        # When the user presses return, we'll move to that directory.
+        self._path_editor.returnPressed.connect(self._path_confirmed)
+
+    def _path_confirmed(self):
+        """
+        When the user presses RETURN in the combo box, we update the current directory to the
+        path specified in the combo box.
+        """
+        self.setDirectory(self._path_editor.text())
 
     def exec_(self):
+        """
+        Shows the window modally and in the foreground.
+
+        :returns: The return code specified by the call to quit().
+        """
         self.show()
         self.raise_()
         self.activateWindow()

--- a/python/tk_framework_desktopserver/sgtk_file_dialog.py
+++ b/python/tk_framework_desktopserver/sgtk_file_dialog.py
@@ -8,6 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+import sys
 
 try:
     from PySide import QtCore, QtGui
@@ -41,6 +42,13 @@ class SgtkFileDialog(QtGui.QFileDialog):
         treeview = self.findChild(QtGui.QTreeView)
         if treeview:
             treeview.setSelectionMode(selection_mode)
+
+        # FIXME: On MacOS the QFileDialog hides all hidden files. Unfortunately /Volumes is hidden.
+        # As a quick hack to unblock our clients, we'll add /Volumes to the sidebar.
+        if sys.platform == "darwin":
+            sidebarUrls = self.sidebarUrls()
+            sidebarUrls.append("file:///Volumes")
+            self.setSidebarUrls(sidebarUrls)
 
     def exec_(self):
         self.show()


### PR DESCRIPTION
On MacOS the QFileDialog hides all hidden files. Unfortunately this means that /Volumes is hidden. As a quick hack to unblock our clients, we'll add /Volumes to the sidebar.