### PR TITLE
For #36848, 0.18 compatible logging

### DIFF
--- a/python/tk_framework_desktopserver/certificates.py
+++ b/python/tk_framework_desktopserver/certificates.py
@@ -106,6 +106,7 @@ class _CertificateHandler(object):
 
         # Do not use popen.check_call because it won't redirect stderr to stdout properly
         # and it can't close stdin which causes issues in certain configurations on Windows.
+        self._logger.debug("%s: %s" % (ctx.capitalize(), cmd))
         if sys.platform == "win32":
             # More on this Windows specific fix here: https://bugs.python.org/issue3905
             p = subprocess.Popen(
@@ -120,7 +121,6 @@ class _CertificateHandler(object):
             p = subprocess.Popen(cmd, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, shell=True)
         stdout, stderr = p.communicate()
         self._logger.debug("Stdout:\n%s" % stdout)
-        self._logger.debug("Stderr:\n%s" % stderr)
         if p.returncode != 0:
             raise CertificateRegistrationError("There was a problem %s." % ctx)
         return stdout
@@ -256,10 +256,17 @@ class _WindowsCertificateHandler(_CertificateHandler):
 
         :returns: True on success, False on failure.
         """
-        return self._check_call(
+        success = self._check_call(
             "registering the certificate",
             ("certutil", "-user", "-addstore", "root", self._cert_path.replace("/", "\\"))
         )
+        # On Windows, a Windows Server can push a group policy that prevents certificate registration
+        # from succeeding. When that happens, certutil actually silently fails. Detect this and
+        # report it.
+        if success and not self.is_registered():
+            raise CertificateRegistrationError(
+                "Certificate registration silently failed. Please contact support@shotgunsoftware.com."
+            )
 
     def unregister(self):
         """

--- a/python/tk_framework_desktopserver/certificates.py
+++ b/python/tk_framework_desktopserver/certificates.py
@@ -119,7 +119,7 @@ class _CertificateHandler(object):
             p.stdin.close()
         else:
             p = subprocess.Popen(cmd, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, shell=True)
-        stdout, stderr = p.communicate()
+        stdout, _ = p.communicate()
         self._logger.debug("Stdout:\n%s" % stdout)
         if p.returncode != 0:
             raise CertificateRegistrationError("There was a problem %s." % ctx)

--- a/python/tk_framework_desktopserver/certificates.py
+++ b/python/tk_framework_desktopserver/certificates.py
@@ -118,9 +118,10 @@ class _CertificateHandler(object):
             p.stdin.close()
         else:
             p = subprocess.Popen(cmd, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, shell=True)
-        stdout, _ = p.communicate()
+        stdout, stderr = p.communicate()
+        self._logger.debug("Stdout:\n%s" % stdout)
+        self._logger.debug("Stderr:\n%s" % stderr)
         if p.returncode != 0:
-            self._logger.error("Unexpected output:\n%s" % stdout)
             raise CertificateRegistrationError("There was a problem %s." % ctx)
         return stdout
 

--- a/python/tk_framework_desktopserver/logger.py
+++ b/python/tk_framework_desktopserver/logger.py
@@ -15,7 +15,8 @@ def get_logger(child_logger=None):
     """
     Returns the logger used by this framework.
     """
+    # Follow 0.18 naming convention so the logging is picked up automatically by the new framework.
     if not child_logger:
-        return logging.getLogger("tk-framework-desktopserver")
+        return logging.getLogger("sgtk.ext.tk-framework-desktopserver")
     else:
-        return logging.getLogger("tk-framework-desktopserver.%s" % child_logger)
+        return logging.getLogger("sgtk.ext.tk-framework-desktopserver.%s" % child_logger)

--- a/python/tk_framework_desktopserver/logger.py
+++ b/python/tk_framework_desktopserver/logger.py
@@ -16,6 +16,8 @@ def get_logger(child_logger=None):
     Returns the logger used by this framework.
     """
     # Follow 0.18 naming convention so the logging is picked up automatically by the new framework.
+    # Note that Toolkit is not available during startup of the Desktop 1.x so we can't rely on the API
+    # to build a proper logger name.
     if not child_logger:
         return logging.getLogger("sgtk.ext.tk-framework-desktopserver")
     else:


### PR DESCRIPTION
Tweaks the logger name of the framework so that it gets picked up automatically when used inside a process using Core 0.18. This change is backwards compatible with the previous version of the Shotgun Desktop.

Added also a bit of logic to catch certificate issues on Windows and updated the logging of commands to the logs.

This will be integrated in the latest desktopstartup, but doesn't require a repackaging of the Desktop installer.
