### PR TITLE
For #34121, unable to generate certificates on Chromeless computers

### DIFF
--- a/python/tk_framework_desktopserver/certificates.py
+++ b/python/tk_framework_desktopserver/certificates.py
@@ -205,7 +205,7 @@ class _LinuxCertificateHandler(_CertificateHandler):
         """
         super(_LinuxCertificateHandler, self).__init__(certificate_folder)
 
-        # Ensure that the Chrome certificate registry is initialized.
+        # Ensure that the Chrome certificate registry folder exists
         if not os.path.exists(self._PKI_DB_PATH):
             self._logger.debug("Creating '%s'", self._PKI_DB_PATH)
             os.makedirs(self._PKI_DB_PATH)


### PR DESCRIPTION
Fixes a crashing bug in Linux on startup when the ~/.pki/nssdb folder doesn't exist or that location has no database.