### PR TITLE
For 40784: Adds websockets protocol v2.

### DIFF
--- a/python/tk_framework_desktopserver/message_host.py
+++ b/python/tk_framework_desktopserver/message_host.py
@@ -36,7 +36,7 @@ class MessageHost(object):
         :param data: Object to send
         """
 
-        message = Message(self._message["id"], self._host.PROTOCOL_VERSION)
+        message = Message(self._message["id"], self._host.protocol_version)
         message.reply(data)
 
         self._send_message(message.data)
@@ -53,7 +53,7 @@ class MessageHost(object):
         :param data: Optional object data to send in reply
         """
         get_logger().info("Websocket client error: %s" % error_message)
-        message = Message(self._message["id"], self._host.PROTOCOL_VERSION)
+        message = Message(self._message["id"], self._host.protocol_version)
         message.error(error_message, error_data)
 
         self._send_message(message.data)

--- a/python/tk_framework_desktopserver/process_manager.py
+++ b/python/tk_framework_desktopserver/process_manager.py
@@ -208,18 +208,6 @@ class ProcessManager(object):
         actions['err'] = err
         actions['retcode'] = code
 
-    def execute_engine_command(self, pipeline_configs, project_id, command, entity_type, entity_id):
-        """
-
-        """
-        return
-
-    def get_actions(self, pipeline_configs, project_id, entity_type, entity_id):
-        """
-
-        """
-        return []
-
     def get_project_actions(self, pipeline_config_paths):
         """
         Get all actions for all environments from project path

--- a/python/tk_framework_desktopserver/process_manager.py
+++ b/python/tk_framework_desktopserver/process_manager.py
@@ -208,6 +208,18 @@ class ProcessManager(object):
         actions['err'] = err
         actions['retcode'] = code
 
+    def execute_engine_command(self, pipeline_configs, project_id, command, entity_type, entity_id):
+        """
+
+        """
+        return
+
+    def get_actions(self, pipeline_configs, project_id, entity_type, entity_id):
+        """
+
+        """
+        return []
+
     def get_project_actions(self, pipeline_config_paths):
         """
         Get all actions for all environments from project path

--- a/python/tk_framework_desktopserver/server_protocol.py
+++ b/python/tk_framework_desktopserver/server_protocol.py
@@ -93,6 +93,7 @@ class ServerProtocol(WebSocketServerProtocol):
             raise websocket.http.HttpException(403, "Domain origin was rejected by server.")
         else:
             self._logger.info("Connection accepted.")
+            self._wss_key = response.headers["sec-websocket-key"]
 
     def onMessage(self, payload, isBinary):
         """
@@ -161,6 +162,7 @@ class ServerProtocol(WebSocketServerProtocol):
                 protocol_version,
                 message_host,
                 self.process_manager,
+                wss_key=self._wss_key,
             )
         except Exception, e:
             message_host.report_error("Unable to get a ShotgunAPI object: %s" % e)

--- a/python/tk_framework_desktopserver/server_protocol.py
+++ b/python/tk_framework_desktopserver/server_protocol.py
@@ -161,7 +161,6 @@ class ServerProtocol(WebSocketServerProtocol):
                 protocol_version,
                 message_host,
                 self.process_manager,
-                self._semaphore,
             )
         except Exception, e:
             message_host.report_error("Unable to get a ShotgunAPI object: %s" % e)

--- a/python/tk_framework_desktopserver/server_protocol.py
+++ b/python/tk_framework_desktopserver/server_protocol.py
@@ -190,8 +190,9 @@ class ServerProtocol(WebSocketServerProtocol):
                 try:
                     func(data)
                 except Exception, e:
+                    import traceback
                     message_host.report_error(
-                        "Method call failed for %s: %s" % (cmd_name, e)
+                        "Method call failed for %s: %s" % (cmd_name, traceback.format_exc())
                     )
                 finally:
                     if requires_sync:

--- a/python/tk_framework_desktopserver/shotgun/__init__.py
+++ b/python/tk_framework_desktopserver/shotgun/__init__.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+def get_shotgun_api(protocol_version, host, process_manager):
+    """
+
+    """
+    if protocol_version == 1:
+        from .api_v1 import ShotgunAPI
+    elif protocol_version == 2:
+        from .api_v2 import ShotgunAPI
+    else:
+        raise RuntimeError("Unsupported protocol version: %s" % protocol_version)
+
+    return ShotgunAPI(host, process_manager)

--- a/python/tk_framework_desktopserver/shotgun/__init__.py
+++ b/python/tk_framework_desktopserver/shotgun/__init__.py
@@ -10,7 +10,8 @@
 
 # We want class-level variables to persist, so we'll setup a cache here
 # that the factory functuon below populates.
-__API_CACHE = dict()
+from . import api_v1
+from . import api_v2
 
 def get_shotgun_api(protocol_version, host, process_manager, wss_key):
     """
@@ -31,18 +32,9 @@ def get_shotgun_api(protocol_version, host, process_manager, wss_key):
     :returns: An RPC API instance appropriate for the given protocol
         version.
     """
-    global __API_CACHE
-
-    if protocol_version in __API_CACHE:
-        ShotgunAPI = __API_CACHE[protocol_version]
+    if protocol_version == 1:
+        return api_v1.ShotgunAPI(host, process_manager, wss_key)
+    elif protocol_version == 2:
+        return api_v2.ShotgunAPI(host, process_manager, wss_key)
     else:
-        if protocol_version == 1:
-            from .api_v1 import ShotgunAPI
-            __API_CACHE[protocol_version] = ShotgunAPI
-        elif protocol_version == 2:
-            from .api_v2 import ShotgunAPI
-            __API_CACHE[protocol_version] = ShotgunAPI
-        else:
-            raise RuntimeError("Unsupported protocol version: %s" % protocol_version)
-
-    return ShotgunAPI(host, process_manager, wss_key)
+        raise RuntimeError("Unsupported protocol version: %s" % protocol_version)

--- a/python/tk_framework_desktopserver/shotgun/__init__.py
+++ b/python/tk_framework_desktopserver/shotgun/__init__.py
@@ -8,7 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-def get_shotgun_api(protocol_version, host, process_manager):
+def get_shotgun_api(protocol_version, host, process_manager, semaphore):
     """
 
     """
@@ -19,4 +19,4 @@ def get_shotgun_api(protocol_version, host, process_manager):
     else:
         raise RuntimeError("Unsupported protocol version: %s" % protocol_version)
 
-    return ShotgunAPI(host, process_manager)
+    return ShotgunAPI(host, process_manager, semaphore)

--- a/python/tk_framework_desktopserver/shotgun/__init__.py
+++ b/python/tk_framework_desktopserver/shotgun/__init__.py
@@ -8,7 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-def get_shotgun_api(protocol_version, host, process_manager, semaphore):
+def get_shotgun_api(protocol_version, host, process_manager):
     """
 
     """
@@ -19,4 +19,4 @@ def get_shotgun_api(protocol_version, host, process_manager, semaphore):
     else:
         raise RuntimeError("Unsupported protocol version: %s" % protocol_version)
 
-    return ShotgunAPI(host, process_manager, semaphore)
+    return ShotgunAPI(host, process_manager)

--- a/python/tk_framework_desktopserver/shotgun/api_v1.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v1.py
@@ -40,7 +40,7 @@ class ShotgunAPI(object):
     # Nothing for v1. This is used in v2.
     SYNCHRONOUS_METHODS = []
 
-    def __init__(self, host, process_manager, semaphore):
+    def __init__(self, host, process_manager, wss_key):
         """
         API Constructor.
         Keep initialization pretty fast as it is created on every message.
@@ -50,6 +50,7 @@ class ShotgunAPI(object):
         """
         self.host = host
         self.process_manager = process_manager
+        self.wss_key = wss_key
 
     def _handle_toolkit_output(self, out, err, return_code):
         """

--- a/python/tk_framework_desktopserver/shotgun/api_v1.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v1.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 Shotgun Software Inc.
+# Copyright (c) 2017 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY
 #
@@ -9,7 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 
-class ShotgunAPI():
+class ShotgunAPI(object):
     """
     Public API For all the commands that can be sent from Shotgun Client.
 
@@ -26,9 +26,16 @@ class ShotgunAPI():
     Public API
     Callable methods from client. Every one of these methods can be called from the client.
     """
-    public_api = ["echo", "open", "executeToolkitCommand", "executeTankCommand",
-                  "pickFileOrDirectory", "pickFilesOrDirectories", "version",
-                  "getProjectActions"]
+    PUBLIC_API_METHODS = [
+        "echo",
+        "open",
+        "executeToolkitCommand",
+        "executeTankCommand",
+        "pickFileOrDirectory",
+        "pickFilesOrDirectories",
+        "version",
+        "getProjectActions",
+    ]
 
     def __init__(self, host, process_manager):
         """
@@ -90,6 +97,18 @@ class ShotgunAPI():
 
         self.host.reply(reply)
 
+    def executeEngineCommand(self, data):
+        """
+
+        """
+        self.process_manager.execute_engine_command(
+            pipeline_configs=data.get("pipeline_configs"),
+            project_id=data.get("project_id"),
+            command=data.get("command"),
+            entity_type=data.get("entity_type"),
+            entity_id=data.get("entity_id"),
+        )
+
     def executeToolkitCommand(self, data):
         """
         Executes a toolkit command.
@@ -119,6 +138,21 @@ class ShotgunAPI():
         Alias for executeToolkitCommand
         """
         return self.executeToolkitCommand(data)
+
+    def getActions(self, data):
+        """
+
+        """
+        self.host.reply(
+            dict(
+                actions=self.process_manager.get_actions(
+                    pipeline_configs=data.get("pipeline_configs"),
+                    project_id=data.get("project_id"),
+                    entity_type=data.get("entity_type"),
+                    entity_id=data.get("entity_id"),
+                )
+            )
+        )
 
     def getProjectActions(self, data):
         """

--- a/python/tk_framework_desktopserver/shotgun/api_v1.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v1.py
@@ -37,7 +37,10 @@ class ShotgunAPI(object):
         "getProjectActions",
     ]
 
-    def __init__(self, host, process_manager):
+    # Nothing for v1. This is used in v2.
+    SYNCHRONOUS_METHODS = []
+
+    def __init__(self, host, process_manager, semaphore):
         """
         API Constructor.
         Keep initialization pretty fast as it is created on every message.

--- a/python/tk_framework_desktopserver/shotgun/api_v1.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v1.py
@@ -103,7 +103,10 @@ class ShotgunAPI(object):
 
     def executeEngineCommand(self, data):
         """
+        Executes the engine command described in the payload sent by the
+        client.
 
+        :param dict data: The payload from the client.
         """
         self.process_manager.execute_engine_command(
             pipeline_configs=data.get("pipeline_configs"),
@@ -145,7 +148,9 @@ class ShotgunAPI(object):
 
     def getActions(self, data):
         """
+        Gets all actions for the given entity.
 
+        :param dict data: The payload sent down by the client.
         """
         self.host.reply(
             dict(

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -106,9 +106,8 @@ class ShotgunAPI(object):
                 )
                 self.host.reply(ret)
             else:
-                # TODO: Second lookup_hash here to be replaced with contents_hash.
                 try:
-                    self._cache_actions(data, lookup_hash, lookup_hash)
+                    self._cache_actions(data)
                 except subprocess.CalledProcessError, e:
                     self.logger.error(str(e))
                     self.host.reply(
@@ -135,7 +134,7 @@ class ShotgunAPI(object):
     ###########################################################################
     # sqlite database access methods
 
-    def _cache_actions(self, data, lookup_hash, contents_hash):
+    def _cache_actions(self, data):
         self.logger.info("Caching engine commands...")
 
         script = os.path.join(
@@ -152,10 +151,7 @@ class ShotgunAPI(object):
                 dict(
                     cache_file=self._cache_path,
                     data=data,
-                    lookup_hash=lookup_hash,
-                    contents_hash=contents_hash,
                     sys_path=sys.path,
-                    entity=dict(type="Project", id=data["project_id"]),
                 ),
                 fh,
                 cPickle.HIGHEST_PROTOCOL,

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -39,7 +39,7 @@ class ShotgunAPI(object):
 
     # Return codes.
     SUCCESSFUL_LOOKUP = 0
-    UPSUPPORTED_ENTITY_TYPE = 2
+    UNSUPPORTED_ENTITY_TYPE = 2
     CACHING_ERROR = 3
 
     # BASE_CONFIG_URI = "sgtk:descriptor:app_store?name=tk-config-basic"
@@ -117,9 +117,9 @@ class ShotgunAPI(object):
         manager = sgtk.bootstrap.ToolkitManager()
         manager.base_configuration = self.BASE_CONFIG_URI
 
-        pcs = manager.get_pipeline_configurations(
-            project_entity,
-            data["pipeline_configs"],
+        pcs = manager.sort_and_filter_configuration_entities(
+            project=project_entity,
+            entities=data["pipeline_configs"],
         ) or [dict(id=None, name="Primary")]
 
         # We'll need to pass up the config names in order along with a dict of
@@ -227,6 +227,7 @@ class ShotgunAPI(object):
                     cache_file=self._cache_path,
                     data=data,
                     sys_path=sys.path,
+                    base_configuration=self.BASE_CONFIG_URI,
                 ),
                 fh,
                 cPickle.HIGHEST_PROTOCOL,

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -374,7 +374,7 @@ class ShotgunAPI(object):
         for pc_id, pc_data in config_data.iteritems():
             hash_data[pc_id] = dict(
                 lookup_hash=config_data[pc_id]["lookup_hash"],
-                contents_hash = config_data[pc_id]["contents_hash"],
+                contents_hash=config_data[pc_id]["contents_hash"],
             )
 
         args_file = self._get_arguments_file(
@@ -609,7 +609,7 @@ class ShotgunAPI(object):
                 entities = self._engine.shotgun.find(**spec)
                 self.WSS_KEY_CACHE[self._wss_key]["site_state_data"].extend(entities)
         else:
-            self.logger.debug("Cached site state data found for %s." % self._wss_key)
+            self.logger.debug("Cached site state data found for %s" % self._wss_key)
 
         return self.WSS_KEY_CACHE[self._wss_key]["site_state_data"]
 
@@ -631,7 +631,7 @@ class ShotgunAPI(object):
                 fields=self._engine.shotgun.schema_field_read("Software").keys(),
             )
         else:
-            self.logger.debug("Cache software entities found for %s." % self._wss_key)
+            self.logger.debug("Cache software entities found for %s" % self._wss_key)
 
         return self.WSS_KEY_CACHE[self._wss_key]["software_entities"]
 

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -51,8 +51,10 @@ class ShotgunAPI(object):
     COMMAND_SUCCEEDED = 0
     COMMAND_FAILED = 1
 
-    # BASE_CONFIG_URI = "sgtk:descriptor:app_store?name=tk-config-basic"
-    BASE_CONFIG_URI = "sgtk:descriptor:dev?name=tk-config-basic&path=/Users/jeff/Documents/repositories/tk-config-basic"
+    BASE_CONFIG_URI = os.environ.get(
+        "SHOTGUN_DESKTOP_CONFIG_FALLBACK_DESCRIPTOR",
+        "sgtk:descriptor:app_store?name=tk-config-basic"
+    )
     ENGINE_NAME = "tk-shotgun"
 
     def __init__(self, host, process_manager, wss_key):

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -1,0 +1,233 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import sys
+import os
+import cPickle
+import md5
+import sqlite3
+import json
+import subprocess
+import tempfile
+
+import sgtk
+
+###########################################################################
+# Decorators
+
+def _db_connect(function):
+    """
+    Decorator helper to use with database methods. This is to reduce
+    code duplication and it passes in a connection and cursor argument
+    to the decorated method. Use it like this:
+    
+        @_db_connect
+        def my_method(self, connection, cursor, note_id):
+            do_stuff
+        
+    The connection and cursor parameters above are added by this decorator,
+    so the calling code should execute the following:
+    
+        do_stuff
+        self.my_method(note_id)
+        do_stuff
+    
+    """
+    def wrap_function(*args, **kwargs):
+        connection = None
+        cursor = None        
+        self = args[0]
+        try:
+            connection = self._init_db()
+            cursor = connection.cursor()
+            new_args = (self, connection, cursor) + args[1:]
+            return function(*new_args, **kwargs)
+        finally:
+            try:
+                if cursor:
+                    cursor.close()
+                if connection:
+                    connection.close()
+            except:
+                self.logger.debug("Could not close database handle.")        
+                    
+    return wrap_function
+
+###########################################################################
+# Classes
+
+class ShotgunAPI(object):
+    """
+    Public API
+    Callable methods from client. Every one of these methods can be called from the client.
+    """
+    PUBLIC_API_METHODS = [
+        "get_actions",
+    ]
+
+    DATABASE_FORMAT_VERSION = 1
+
+    def __init__(self, host, process_manager):
+        """
+        API Constructor.
+        Keep initialization pretty fast as it is created on every message.
+
+        :param host: Host interface to communicate with. Abstracts the client.
+        :param process_manager: Process Manager to use to interact with os processes.
+        """
+        self._host = host
+        self._process_manager = process_manager
+        self._engine = sgtk.platform.current_engine()
+
+        # Cache path on disk.
+        self._cache_path = os.path.join(
+            self._engine.cache_location, 
+            "shotgun_engine_commands_v%s.sqlite" % self.DATABASE_FORMAT_VERSION,
+        )
+
+    ###########################################################################
+    # Properties
+
+    @property
+    def logger(self):
+        return sgtk.platform.current_engine().logger
+
+    @property
+    def host(self):
+        return self._host
+
+    @property
+    def process_manager(self):
+        return self._process_manager
+
+    ###########################################################################
+    # Public methods
+
+    @_db_connect
+    def get_actions(self, connection, cursor, data):
+        # TODO: Core hook to generate lookup hash.
+        lookup_md5 = md5.new()
+        lookup_md5.update(str(data))
+        lookup_hash = lookup_md5.digest()
+
+        # TODO: Compute contents_hash and ensure it matches that in the cache.
+        res = list(cursor.execute(
+            "SELECT commands FROM engine_commands WHERE lookup_hash=?",
+            (lookup_hash,)
+        ))
+
+        if res:
+            commands = cPickle.loads(str(list(res)[0][0]))
+            self.logger.debug("Commands found in cache: %s" % commands)
+            ret = dict(
+                err="",
+                retcode=0,
+                out=commands,
+            )
+            self.host.reply(ret)
+        else:
+            # TODO: Second lookup_hash here to be replaced with contents_hash.
+            self._cache_actions(data, lookup_hash, lookup_hash)
+            self.get_actions(data)
+
+    ###########################################################################
+    # sqlite database access methods
+
+    def _cache_actions(self, data, lookup_hash, contents_hash):
+        self.logger.info("Caching engine commands...")
+
+        script = os.path.join(
+            os.path.dirname(__file__),
+            "scripts",
+            "cache_commands.py"
+        )
+
+        self.logger.debug("Executing script: %s" % script)
+        args_file = tempfile.mkstemp()[1]
+
+        with open(args_file, "w") as fh:
+            cPickle.dump(
+                dict(
+                    cache_file=self._cache_path,
+                    data=data,
+                    lookup_hash=lookup_hash,
+                    contents_hash=contents_hash,
+                ),
+                fh,
+                cPickle.HIGHEST_PROTOCOL,
+            )
+
+        subprocess.check_call([sys.executable, script, args_file])
+        self.logger.info("Caching complete.")
+
+    def _init_db(self):
+        """
+        Sets up the database if it doesn't exist.
+
+        :returns: A handle that must be closed.
+        """
+        connection = sqlite3.connect(self._cache_path)
+        self.logger.info("Cache path is %s" % self._cache_path)
+
+        # This is to handle unicode properly - make sure that sqlite returns 
+        # str objects for TEXT fields rather than unicode. Note that any unicode
+        # objects that are passed into the database will be automatically
+        # converted to UTF-8 strs, so this text_factory guarantees that any character
+        # representation will work for any language, as long as data is either input
+        # as UTF-8 (byte string) or unicode. And in the latter case, the returned data
+        # will always be unicode.
+        connection.text_factory = str
+        c = connection.cursor()
+
+        try:
+            # Get a list of tables in the current database.
+            ret = c.execute("SELECT name FROM main.sqlite_master WHERE type='table';")
+            table_names = [x[0] for x in ret.fetchall()]
+
+            if not table_names:
+                self.logger.debug("Creating schema in sqlite db.")
+
+                # We have a brand new database. Create all tables and indices.
+                c.executescript("""
+                    CREATE TABLE engine_commands (lookup_hash text, contents_hash text, commands blob);
+                """)
+                # c.executescript("""
+                #     -- CREATE TABLE entity (entity_type text, entity_id integer, activity_id integer, created_at datetime);
+
+                #     -- CREATE TABLE activity (activity_id integer, note_id integer default null, payload blob, created_at datetime);
+
+                #     -- CREATE TABLE note (note_id integer, payload blob, created_at datetime);
+
+                #     -- CREATE INDEX entity_1 ON entity(entity_type, entity_id, created_at);
+                #     -- CREATE INDEX entity_2 ON entity(entity_type, entity_id, activity_id, created_at);
+
+                #     -- CREATE INDEX activity_1 ON activity(activity_id);
+                #     -- CREATE INDEX activity_2 ON activity(activity_id, note_id);
+
+                #     -- CREATE INDEX note_1 ON activity(note_id);
+                # """)
+                connection.commit()
+        except Exception:
+            connection.close()
+            c = None
+            raise
+        finally:
+            if c:
+                c.close()
+
+        return connection
+
+
+
+
+
+
+
+

--- a/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
@@ -47,8 +47,21 @@ def get_sgtk_logger(sgtk):
 
     return sgtk_logger, bootstrap_log_handler
 
-def get_lookup_hash(sgtk, engine, entity):
-    pc = engine.sgtk.pipeline_configuration
+def get_contents_hash(tk, entity_type, pc_descriptor):
+    return tk.execute_core_hook_method(
+        "browser_integration",
+        "get_cache_contents_hash",
+        entity_type=entity_type,
+        pc_descriptor=pc_descriptor,
+    )
+
+def get_lookup_hash(tk, entity_type, pc_descriptor):
+    return tk.execute_core_hook_method(
+        "browser_integration",
+        "get_cache_lookup_hash",
+        entity_type=entity_type,
+        pc_descriptor=pc_descriptor,
+    )
 
 def cache(cache_file, data):
     import sqlite3
@@ -56,9 +69,10 @@ def cache(cache_file, data):
 
     entity = dict(type=data["entity_type"], id=data["entity_id"])
 
-    # set up the toolkit boostrap manager
+    # Setup the bootstrap manager.
     toolkit_mgr = sgtk.bootstrap.ToolkitManager()
     toolkit_mgr.plugin_id = "shotgun_toolkit_menu_caching"
+
     # toolkit_mgr.base_configuration = "sgtk:descriptor:app_store?name=tk-config-basic"
     toolkit_mgr.base_configuration = "sgtk:descriptor:dev?name=tk-config-basic&path=/Users/jeff/Documents/repositories/tk-config-basic"
 
@@ -68,7 +82,7 @@ def cache(cache_file, data):
     pcs = toolkit_mgr.get_pipeline_configurations(
         project=dict(id=data["project_id"], type="Project"),
         pc_entities=data["pipeline_configs"],
-    )
+    ) or [dict(id=None)]
 
     for pc in pcs:
         logger, log_handler = get_sgtk_logger(sgtk)
@@ -77,17 +91,19 @@ def cache(cache_file, data):
 
         toolkit_mgr.pipeline_configuration = pc["id"]
         engine = toolkit_mgr.bootstrap_engine("tk-shotgun", entity=entity)
-        pc_descriptor = toolkit_mgr.get_pipeline_configuration_descriptor(data["project_id"])
+        pc_descriptor = toolkit_mgr.get_resolved_pipeline_configuration_descriptor(
+            data["project_id"],
+        )
 
         logger.info("Bootstrap complete!")
         logger.info("PC descriptor: %s" % pc_descriptor.get_uri())
 
+        # Clean up the pre-bootstrap logger since we can use the engine's
+        # logger from here on out.
         sgtk.LogManager().root_logger.removeHandler(log_handler)
         engine.logger.info("Removed bootstrap log handler from root logger.")
-
-        commands = []
-
         engine.logger.info("Processing engine commands...")
+        commands = []
 
         for cmd_name, data in engine.commands.iteritems():
             engine.logger.info("Processing command: %s" % cmd_name)
@@ -104,12 +120,25 @@ def cache(cache_file, data):
         engine.logger.info("Engine commands processed.")
         engine.logger.info("Inserting into cache...")
 
+        # Connect to the database and get the hashes we need to include in
+        # the insert. Each of the lookups call out to the browser_integration
+        # core hook.
         connection = sqlite3.connect(cache_file)
         connection.text_factory = str
         cursor = connection.cursor()
 
-        lookup_hash = get_lookup_hash(sgtk, engine, entity)
-        contents_hash = get_contents_hash(sgtk, engine, entity)
+        lookup_hash = get_lookup_hash(
+            engine.sgtk,
+            entity["type"],
+            pc_descriptor,
+        )
+        contents_hash = get_contents_hash(
+            engine.sgtk,
+            entity["type"],
+            pc_descriptor,
+        )
+
+        engine.logger.info("Lookup hash: %s" % lookup_hash)
 
         try:
             cursor.execute(
@@ -123,10 +152,12 @@ def cache(cache_file, data):
         finally:
             connection.close()
 
+        # Tear down the engine. This is both good practice before we exit
+        # this process, but also necessary if there are multiple pipeline
+        # configs that we're iterating over.
         logger.debug("Shutting down engine...")
         engine.destroy()
         logger.debug("Engine shutdown complete.")
-    logger.info("Caching complete!")
 
 if __name__ == "__main__":
     arg_data_file = sys.argv[1]

--- a/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
@@ -1,28 +1,122 @@
 
 import sys
-import sqlite3
+import logging
 import cPickle
 
-def cache(cache_file, data, lookup_hash, contents_hash):
+class _BootstrapLogHandler(logging.StreamHandler):
+    """
+    Manually flushes emitted records for js to pickup.
+    """
+
+    def emit(self, record):
+        """
+        Forwards the record back to to js via the engine communicator.
+
+        :param record: The record to log.
+        """
+        super(_BootstrapLogHandler, self).emit(record)
+
+        # always flush to ensure its seen by the js process
+        self.flush()
+
+def get_sgtk_logger(sgtk):
+    """
+    Sets up a log handler and logger.
+
+    :param sgtk: An sgtk module reference.
+
+    :returns: A logger and log handler.
+    """
+    # add a custom handler to the root logger so that all toolkit log messages
+    # are forwarded back to python via the communicator
+    bootstrap_log_formatter = logging.Formatter("[%(levelname)s]: %(message)s")
+    bootstrap_log_handler = _BootstrapLogHandler()
+    bootstrap_log_handler.setFormatter(bootstrap_log_formatter)
+    bootstrap_log_handler.setLevel(logging.DEBUG)
+
+    # now get a logger to use during bootstrap
+    sgtk_logger = sgtk.LogManager.get_logger("%s.%s" % ("tk-shotgun", "bootstrap"))
+    sgtk.LogManager().initialize_custom_handler(bootstrap_log_handler)
+
+    # allows for debugging to be turned on by the plugin build process
+    sgtk.LogManager().global_debug = True
+
+    # initializes the file where logging output will go
+    sgtk.LogManager().initialize_base_file_handler("tk-shotgun")
+    sgtk_logger.debug("Log dir: %s" % (sgtk.LogManager().log_folder))
+
+    return sgtk_logger, bootstrap_log_handler
+
+def cache(cache_file, data, lookup_hash, contents_hash, entity):
     import sqlite3
+    import sgtk
 
-    connection = sqlite3.connect(cache_file)
-    connection.text_factory = str
-    cursor = connection.cursor()
+    logger, log_handler = get_sgtk_logger(sgtk)
+    logger.info("Bootstrap logger up and running.")
 
-     # TODO: bootstrap and get commands
-    try:
-        commands = [dict(name="YYYYAAAAAAAYYYYY")]
-        cursor.execute(
-            "INSERT INTO engine_commands VALUES (?, ?, ?)", (
-                lookup_hash,
-                contents_hash,
-                sqlite3.Binary(cPickle.dumps(commands, cPickle.HIGHEST_PROTOCOL)),
+    # set up the toolkit boostrap manager
+    toolkit_mgr = sgtk.bootstrap.ToolkitManager()
+    toolkit_mgr.plugin_id = "shotgun_toolkit_menu_caching"
+    # toolkit_mgr.base_configuration = "sgtk:descriptor:app_store?name=tk-config-basic"
+    toolkit_mgr.base_configuration = "sgtk:descriptor:dev?name=tk-config-basic&path=/Users/jeff/Documents/repositories/tk-config-basic"
+
+    logger.info("ToolkitManager constructed.")
+
+    for pc in data["pipeline_configs"]:
+        pc["project"] = pc.get("project", dict(type="Project", id=pc["project_id"]))
+        pc["type"] = pc.get("type", "PipelineConfiguration")
+
+    pcs = toolkit_mgr.get_pipeline_configurations(
+        project=dict(id=data["project_id"], type="Project"),
+        pc_entities=data["pipeline_configs"],
+    )
+
+    for pc in pcs:
+        logger.info("Bootstrapping pipeline configuration id %s..." % pc["id"])
+        toolkit_mgr.pipeline_configuration = pc["id"]
+        engine = toolkit_mgr.bootstrap_engine("tk-shotgun", entity=entity)
+        logger.info("Bootstrap complete!")
+
+        sgtk.LogManager().root_logger.removeHandler(log_handler)
+        engine.logger.info("Removed bootstrap log handler from root logger.")
+
+        commands = []
+
+        engine.logger.info("Iterating over engine commands...")
+
+        try:
+            for cmd_name, data in engine.commands.iteritems():
+                props = data["properties"]
+                commands.append(
+                    dict(
+                        name=cmd_name,
+                        title=props.get("title", cmd_name),
+                        deny_permissions=[], # TODO: figure out user permissions.
+                        supports_multiple_selection=False, # TODO: figure out multiselect.
+                    ),
+                )
+        finally:
+            engine.logger.debug("Shutting down engine...")
+            engine.destroy()
+            engine.logger.debug("Engine shutdown complete.")
+
+        connection = sqlite3.connect(cache_file)
+        connection.text_factory = str
+        cursor = connection.cursor()
+
+        try:
+            cursor.execute(
+                "INSERT INTO engine_commands VALUES (?, ?, ?)", (
+                    lookup_hash,
+                    contents_hash,
+                    sqlite3.Binary(cPickle.dumps(commands, cPickle.HIGHEST_PROTOCOL)),
+                )
             )
-        )
-        connection.commit()
-    finally:
-        connection.close()
+            connection.commit()
+        finally:
+            connection.close()
+
+    engine.logger.info("Caching complete!")
 
 if __name__ == "__main__":
     arg_data_file = sys.argv[1]
@@ -30,11 +124,14 @@ if __name__ == "__main__":
     with open(arg_data_file, "r") as fh:
         arg_data = cPickle.load(fh)
 
+    sys.path = arg_data["sys_path"]
+
     cache(
         arg_data["cache_file"],
         arg_data["data"],
         arg_data["lookup_hash"],
         arg_data["contents_hash"],
+        arg_data["entity"],
     )
 
     sys.exit(0)

--- a/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
@@ -1,0 +1,41 @@
+
+import sys
+import sqlite3
+import cPickle
+
+def cache(cache_file, data, lookup_hash, contents_hash):
+    import sqlite3
+
+    connection = sqlite3.connect(cache_file)
+    connection.text_factory = str
+    cursor = connection.cursor()
+
+     # TODO: bootstrap and get commands
+    try:
+        commands = [dict(name="YYYYAAAAAAAYYYYY")]
+        cursor.execute(
+            "INSERT INTO engine_commands VALUES (?, ?, ?)", (
+                lookup_hash,
+                contents_hash,
+                sqlite3.Binary(cPickle.dumps(commands, cPickle.HIGHEST_PROTOCOL)),
+            )
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+if __name__ == "__main__":
+    arg_data_file = sys.argv[1]
+
+    with open(arg_data_file, "r") as fh:
+        arg_data = cPickle.load(fh)
+
+    cache(
+        arg_data["cache_file"],
+        arg_data["data"],
+        arg_data["lookup_hash"],
+        arg_data["contents_hash"],
+    )
+
+    sys.exit(0)
+    

--- a/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
@@ -47,11 +47,10 @@ def get_sgtk_logger(sgtk):
 
     return sgtk_logger, bootstrap_log_handler
 
-def get_contents_hash(tk, entity_type, pc_descriptor):
+def get_contents_hash(tk, pc_descriptor):
     return tk.execute_core_hook_method(
         "browser_integration",
         "get_cache_contents_hash",
-        entity_type=entity_type,
         pc_descriptor=pc_descriptor,
     )
 
@@ -68,6 +67,7 @@ def cache(cache_file, data):
     import sgtk
 
     entity = dict(type=data["entity_type"], id=data["entity_id"])
+    project_entity = dict(id=data["project_id"], type="Project")
 
     # Setup the bootstrap manager.
     toolkit_mgr = sgtk.bootstrap.ToolkitManager()
@@ -77,36 +77,28 @@ def cache(cache_file, data):
     toolkit_mgr.base_configuration = "sgtk:descriptor:dev?name=tk-config-basic&path=/Users/jeff/Documents/repositories/tk-config-basic"
 
     for pc in data["pipeline_configs"]:
-        pc["project"] = pc.get("project", dict(type="Project", id=data["project_id"]))
+        pc["project"] = pc.get("project", project_entity)
 
     pcs = toolkit_mgr.get_pipeline_configurations(
-        project=dict(id=data["project_id"], type="Project"),
-        pc_entities=data["pipeline_configs"],
+        project_entity,
+        data["pipeline_configs"],
     ) or [dict(id=None)]
 
     for pc in pcs:
         logger, log_handler = get_sgtk_logger(sgtk)
-        logger.info("Bootstrap logger up and running.")
-        logger.info("Bootstrapping pipeline configuration [id=%s]..." % pc["id"])
 
         toolkit_mgr.pipeline_configuration = pc["id"]
         engine = toolkit_mgr.bootstrap_engine("tk-shotgun", entity=entity)
-        pc_descriptor = toolkit_mgr.get_resolved_pipeline_configuration_descriptor(
-            data["project_id"],
-        )
-
-        logger.info("Bootstrap complete!")
-        logger.info("PC descriptor: %s" % pc_descriptor.get_uri())
+        pc_descriptor = toolkit_mgr.resolve_descriptor(project_entity)
 
         # Clean up the pre-bootstrap logger since we can use the engine's
         # logger from here on out.
         sgtk.LogManager().root_logger.removeHandler(log_handler)
-        engine.logger.info("Removed bootstrap log handler from root logger.")
-        engine.logger.info("Processing engine commands...")
+        engine.logger.debug("Processing engine commands...")
         commands = []
 
         for cmd_name, data in engine.commands.iteritems():
-            engine.logger.info("Processing command: %s" % cmd_name)
+            engine.logger.debug("Processing command: %s" % cmd_name)
             props = data["properties"]
             commands.append(
                 dict(
@@ -117,8 +109,8 @@ def cache(cache_file, data):
                 ),
             )
 
-        engine.logger.info("Engine commands processed.")
-        engine.logger.info("Inserting into cache...")
+        engine.logger.debug("Engine commands processed.")
+        engine.logger.debug("Inserting commands into cache...")
 
         # Connect to the database and get the hashes we need to include in
         # the insert. Each of the lookups call out to the browser_integration
@@ -127,27 +119,40 @@ def cache(cache_file, data):
         connection.text_factory = str
         cursor = connection.cursor()
 
-        lookup_hash = get_lookup_hash(
-            engine.sgtk,
-            entity["type"],
-            pc_descriptor,
-        )
-        contents_hash = get_contents_hash(
-            engine.sgtk,
-            entity["type"],
-            pc_descriptor,
-        )
-
-        engine.logger.info("Lookup hash: %s" % lookup_hash)
-
         try:
-            cursor.execute(
-                "INSERT INTO engine_commands VALUES (?, ?, ?)", (
-                    lookup_hash,
-                    contents_hash,
-                    sqlite3.Binary(cPickle.dumps(commands, cPickle.HIGHEST_PROTOCOL)),
-                )
+            lookup_hash = get_lookup_hash(
+                engine.sgtk,
+                entity["type"],
+                pc_descriptor,
             )
+            contents_hash = get_contents_hash(
+                engine.sgtk,
+                pc_descriptor,
+            )
+            commands_blob = sqlite3.Binary(
+                cPickle.dumps(commands, cPickle.HIGHEST_PROTOCOL)
+            )
+
+            # Since we're likely to be updating out-of-date cached data more
+            # often than we're going to be inserting new rows into the cache,
+            # we'll try an update first. If no rows were affected by the update,
+            # we move on to an insert.
+            cursor.execute(
+                "UPDATE engine_commands SET contents_hash=?, commands=? WHERE lookup_hash=?",
+                (contents_hash, commands_blob, lookup_hash)
+            )
+
+            if cursor.rowcount == 0:
+                engine.logger.debug(
+                    "Update did not result in any rows altered, inserting..."
+                )
+                cursor.execute(
+                    "INSERT INTO engine_commands VALUES (?, ?, ?)", (
+                        lookup_hash,
+                        contents_hash,
+                        commands_blob,
+                    )
+                )
             connection.commit()
         finally:
             connection.close()

--- a/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import sys
+import cPickle
+import os
+
+def execute(config, project, name, entities, base_configuration, engine_name):
+    import sgtk
+
+    ms_flag = sgtk.platform.constants.LEGACY_MULTI_SELECT_ACTION_FLAG
+
+    # Setup the bootstrap manager.
+    toolkit_mgr = sgtk.bootstrap.ToolkitManager()
+    toolkit_mgr.plugin_id = "shotgun_toolkit_command_execution"
+    toolkit_mgr.base_configuration = base_configuration
+
+    if config:
+        toolkit_mgr.pipeline_configuration = config.get("id")
+
+    if entities:
+        entity = entities[0]
+    else:
+        entity = project
+
+    engine = toolkit_mgr.bootstrap_engine(engine_name, entity=entity)
+    core_root = os.path.join(
+        engine.sgtk.pipeline_configuration.get_install_location(),
+        "install",
+        "core",
+        "python"
+    )
+    sgtk.util.prepend_path_to_env_var(
+        "PYTHONPATH",
+        core_root,
+    )
+
+    command = engine.commands.get(name)
+
+    if not command:
+        msg = "Unable to find engine command: %s" % name
+        engine.logger.error(msg)
+        raise RuntimeError(msg)
+
+    props = command["properties"]
+    old_style = ms_flag in props
+
+    if old_style:
+        entity_ids = [e["id"] for e in entities]
+        entity_type = entity["type"]
+        engine.execute_old_style_command(name, entity_type, entity_ids)
+    else:
+        engine.execute_command(name)
+
+if __name__ == "__main__":
+    arg_data_file = sys.argv[1]
+
+    with open(arg_data_file, "r") as fh:
+        arg_data = cPickle.load(fh)
+
+    sys.path = arg_data["sys_path"]
+
+    execute(
+        arg_data["config"],
+        arg_data["project"],
+        arg_data["name"],
+        arg_data["entities"],
+        arg_data["base_configuration"],
+        arg_data["engine_name"],
+    )
+
+    sys.exit(0)
+

--- a/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
@@ -19,7 +19,7 @@ def execute(config, project, name, entities, base_configuration, engine_name):
 
     # Setup the bootstrap manager.
     toolkit_mgr = sgtk.bootstrap.ToolkitManager()
-    toolkit_mgr.plugin_id = "shotgun_toolkit_command_execution"
+    toolkit_mgr.plugin_id = "basic.shotgun.execute"
     toolkit_mgr.base_configuration = base_configuration
 
     if config:


### PR DESCRIPTION
This is more expansive than just 40784, and covers all desktopserver changes made thus far for websockets v2.

The ShotgunAPI has been broken out into v1 and v2 variants, and a factory function is provided to choose and instantiate the correct API for a given protocol version. The v1 API is almost entirely untouched, other than having been moved into a new location.

The v2 API provides `get_actions` and `execute_action` public RPC methods. All caching-related logic is managed by `get_actions`. All command execution is handled by `execute_action`.

The cache is populated by way of a subprocess that bootstraps SGTK into the tk-shotgun engine. A list of engine commands is pulled from the engine, munged a bit, and then cached into an sqlite database along with a unique identifier built from the pipeline configuration URI and entity type. A contents state hash is computed from a list of entities queried from the site (all Software entities, by default) and, if the pipeline config is mutable, the modtimes of all yml files found within.

Commands are run via a subprocess that bootstraps into the tk-shotgun engine and calling the associated engine command's callback.