### PR TITLE
Fixes self-signed certificate with Chrome 58+

### DIFF
--- a/python/tk_framework_desktopserver/certificates.py
+++ b/python/tk_framework_desktopserver/certificates.py
@@ -18,6 +18,15 @@ from .errors import CertificateRegistrationError
 from OpenSSL import crypto
 
 
+def get_certificate_file_names(root_folder):
+    """
+    Returns a tuple of certificate file paths.
+
+    :returns: The tuple (public key path, private key path)
+    """
+    return os.path.join(root_folder, "server3.crt"), os.path.join(root_folder, "server3.key")
+
+
 class _CertificateHandler(object):
     """
     Handles creation and registration of the websocket certificate.
@@ -28,8 +37,7 @@ class _CertificateHandler(object):
         :param str certificate_folder: Path where the certificates will be written.
         """
         self._logger = get_logger("certificates")
-        self._cert_path = os.path.join(certificate_folder, "server.crt")
-        self._key_path = os.path.join(certificate_folder, "server.key")
+        self._cert_path, self._key_path = get_certificate_file_names(certificate_folder)
 
     def exists(self):
         """
@@ -62,6 +70,16 @@ class _CertificateHandler(object):
 
         # create a self-signed cert
         cert = crypto.X509()
+
+        # Chrome deprecated CN matching
+        # https://textslashplain.com/2017/03/10/chrome-deprecates-subject-cn-matching/
+        # This fixes the issue: http://stackoverflow.com/a/37440167/1074536
+        san_list = ["DNS:localhost"]
+        cert.add_extensions([
+            crypto.X509Extension(
+                "subjectAltName", False, ", ".join(san_list)
+            )
+        ])
         cert.get_subject().C = "US"
         cert.get_subject().ST = "California"
         cert.get_subject().L = "San Rafael"

--- a/python/tk_framework_desktopserver/certificates.py
+++ b/python/tk_framework_desktopserver/certificates.py
@@ -24,7 +24,7 @@ def get_certificate_file_names(root_folder):
 
     :returns: The tuple (public key path, private key path)
     """
-    return os.path.join(root_folder, "server3.crt"), os.path.join(root_folder, "server3.key")
+    return os.path.join(root_folder, "server2.crt"), os.path.join(root_folder, "server2.key")
 
 
 class _CertificateHandler(object):

--- a/python/tk_framework_desktopserver/server.py
+++ b/python/tk_framework_desktopserver/server.py
@@ -20,6 +20,7 @@ from twisted.python import log
 from autobahn.twisted.websocket import WebSocketServerFactory, listenWS
 
 from .errors import MissingCertificateError, PortBusyError
+from . import certificates
 
 import logger
 
@@ -94,9 +95,7 @@ class Server(object):
 
         :param debug: Boolean Show debug output. Will also Start local web server to test client pages.
         """
-
-        cert_key_path = os.path.join(self._keys_path, "server.key")
-        cert_crt_path = os.path.join(self._keys_path, "server.crt")
+        cert_crt_path, cert_key_path = certificates.get_certificate_file_names(self._keys_path)
 
         self._raise_if_missing_certificate(cert_key_path)
         self._raise_if_missing_certificate(cert_crt_path)


### PR DESCRIPTION
Chrome deprecated CN matching: https://textslashplain.com/2017/03/10/chrome-deprecates-subject-cn-matching/
This fixes the issue: http://stackoverflow.com/a/37440167/1074536