### PR TITLE
For #42157: Supports legacy shotgun_*.yml environments.

### DIFF
--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -140,7 +140,7 @@ class ShotgunAPI(object):
                 project=project_entity,
                 sys_path=sys.path,
                 base_configuration=constants.BASE_CONFIG_URI,
-                engine_name=sgtk.platform.constants.SHOTGUN_ENGINE_NAME,
+                engine_name=constants.ENGINE_NAME,
             ),
         )
 
@@ -250,7 +250,7 @@ class ShotgunAPI(object):
             manager.pipeline_configuration = pc["id"]
             pc_descriptor = manager.resolve_descriptor(project_entity)
 
-            self.logger.debug("Resolved config descriptor: %s" % pc_descriptor)
+            self.logger.debug("Resolved config descriptor: %r" % pc_descriptor)
             pc_key = pc_descriptor.get_uri()
 
             pc_data = dict()
@@ -397,7 +397,7 @@ class ShotgunAPI(object):
                 sys_path=sys.path,
                 base_configuration=constants.BASE_CONFIG_URI,
                 hash_data=hash_data,
-                engine_name=sgtk.platform.constants.SHOTGUN_ENGINE_NAME,
+                engine_name=constants.ENGINE_NAME,
             )
         )
 
@@ -476,7 +476,14 @@ class ShotgunAPI(object):
         filtered = []
 
         for action in actions:
-            if "engine_name" not in action:
+            # The engine_name property of an engine command is defined by
+            # tk-multi-launchapp, and corresponds to the engine that provided
+            # the information necessary to register the launcher. If the action
+            # doesn't include that key, then it means the underlying engine
+            # command did not provide that property, and as such is not a
+            # launcher. Similarly, if it's set to None then the same applies
+            # and we don't need to test this action for filtering purposes.
+            if action.get("engine_name") is None:
                 continue
 
             # We're only interested in entities that are referring to the
@@ -489,7 +496,7 @@ class ShotgunAPI(object):
             for sw in associated_sw:
                 for sw_project in sw.get("projects", []):
                     if sw_project["id"] != project["id"]:
-                        self.logger.info("Action %s filtered out due to SW entity projects." % action)
+                        self.logger.debug("Action %s filtered out due to SW entity projects." % action)
                         filtered.append(action)
                         break
                 if action in filtered:
@@ -768,7 +775,7 @@ class ShotgunAPI(object):
                 self.logger.debug("Keeping command %s -- it has an associated app." % command)
                 filtered.append(command)
             else:
-                self.logger.info(
+                self.logger.debug(
                     "Command %s filtered out for browser integration." % command
                 )
 

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -52,10 +52,13 @@ class ShotgunAPI(object):
     COMMAND_SUCCEEDED = 0
     COMMAND_FAILED = 1
 
-    BASE_CONFIG_URI = os.environ.get(
-        "TK_BOOTSTRAP_CONFIG_OVERRIDE",
-        "sgtk:descriptor:app_store?name=tk-config-basic"
-    )
+    OVERRIDE_CONFIG_PATH = os.environ.get("TK_BOOTSTRAP_CONFIG_OVERRIDE")
+
+    if OVERRIDE_CONFIG_PATH is not None:
+        BASE_CONFIG_URI = "sgtk:descriptor:dev?path=%s" % OVERRIDE_CONFIG_PATH
+    else:
+        BASE_CONFIG_URI = "sgtk:descriptor:app_store?name=tk-config-basic"
+
     ENGINE_NAME = "tk-shotgun"
 
     def __init__(self, host, process_manager, wss_key):

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -23,6 +23,7 @@ import datetime
 import sgtk
 from sgtk.commands.clone_configuration import clone_pipeline_configuration_html
 from sgtk.util import process
+from . import constants
 
 ###########################################################################
 # Classes
@@ -42,24 +43,7 @@ class ShotgunAPI(object):
 
     # Stores data persistently per wss connection.
     WSS_KEY_CACHE = dict()
-
     DATABASE_FORMAT_VERSION = 1
-
-    # Return codes.
-    SUCCESSFUL_LOOKUP = 0
-    UNSUPPORTED_ENTITY_TYPE = 2
-    CACHING_ERROR = 3
-    COMMAND_SUCCEEDED = 0
-    COMMAND_FAILED = 1
-
-    OVERRIDE_CONFIG_PATH = os.environ.get("TK_BOOTSTRAP_CONFIG_OVERRIDE")
-
-    if OVERRIDE_CONFIG_PATH is not None:
-        BASE_CONFIG_URI = "sgtk:descriptor:dev?path=%s" % OVERRIDE_CONFIG_PATH
-    else:
-        BASE_CONFIG_URI = "sgtk:descriptor:app_store?name=tk-config-basic"
-
-    ENGINE_NAME = "tk-shotgun"
 
     def __init__(self, host, process_manager, wss_key):
         """
@@ -117,7 +101,7 @@ class ShotgunAPI(object):
             except Exception as e:
                 self.host.reply(
                     dict(
-                        retcode=self.COMMAND_FAILED,
+                        retcode=constants.COMMAND_FAILED,
                         err=str(e),
                         out=str(e),
                     ),
@@ -127,7 +111,7 @@ class ShotgunAPI(object):
                 self.logger.debug("Clone configuration successful.")
                 self.host.reply(
                     dict(
-                        retcode=self.COMMAND_SUCCEEDED,
+                        retcode=constants.COMMAND_SUCCEEDED,
                         err="",
                         out="",
                     ),
@@ -154,8 +138,8 @@ class ShotgunAPI(object):
                 entities=entities,
                 project=project_entity,
                 sys_path=sys.path,
-                base_configuration=self.BASE_CONFIG_URI,
-                engine_name=self.ENGINE_NAME,
+                base_configuration=constants.BASE_CONFIG_URI,
+                engine_name=sgtk.platform.constants.SHOTGUN_ENGINE_NAME,
             ),
         )
 
@@ -193,7 +177,7 @@ class ShotgunAPI(object):
         self.logger.debug("Command execution complete.")
         self.host.reply(
             dict(
-                retcode=self.COMMAND_SUCCEEDED,
+                retcode=constants.COMMAND_SUCCEEDED,
                 out="Command executed successfully.",
                 err="",
             ),
@@ -235,11 +219,11 @@ class ShotgunAPI(object):
         env_name = self.__pick_environment(project_entity, entity)
 
         if env_name is None:
-            self.host.reply(dict(retcode=self.UNSUPPORTED_ENTITY_TYPE))
+            self.host.reply(dict(retcode=constants.UNSUPPORTED_ENTITY_TYPE))
             return
 
         manager = sgtk.bootstrap.ToolkitManager(allow_config_overrides=False)
-        manager.base_configuration = self.BASE_CONFIG_URI
+        manager.base_configuration = constants.BASE_CONFIG_URI
         pcs = self._get_pipeline_configurations(
             manager,
             project_entity,
@@ -338,7 +322,7 @@ class ShotgunAPI(object):
                     self.host.reply(
                         dict(
                             err="Shotgun Desktop failed to get engine commands.",
-                            retcode=self.CACHING_ERROR,
+                            retcode=constants.CACHING_ERROR,
                             out="Caching failed!",
                         ),
                     )
@@ -347,7 +331,7 @@ class ShotgunAPI(object):
         self.host.reply(
             dict(
                 err="",
-                retcode=self.SUCCESSFUL_LOOKUP,
+                retcode=constants.SUCCESSFUL_LOOKUP,
                 actions=all_actions,
                 pcs=pc_names,
             ),
@@ -411,9 +395,9 @@ class ShotgunAPI(object):
                 cache_file=self._cache_path,
                 data=data,
                 sys_path=sys.path,
-                base_configuration=self.BASE_CONFIG_URI,
+                base_configuration=constants.BASE_CONFIG_URI,
                 hash_data=hash_data,
-                engine_name=self.ENGINE_NAME,
+                engine_name=sgtk.platform.constants.SHOTGUN_ENGINE_NAME,
             )
         )
 

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -238,12 +238,14 @@ class ShotgunAPI(object):
             self.host.reply(dict(retcode=self.UNSUPPORTED_ENTITY_TYPE))
             return
 
-        manager = sgtk.bootstrap.ToolkitManager()
+        manager = sgtk.bootstrap.ToolkitManager(allow_config_overrides=False)
         manager.base_configuration = self.BASE_CONFIG_URI
         pcs = self._get_pipeline_configurations(
             manager,
             project_entity,
         ) or [dict(id=None, name="Primary")]
+
+        self.logger.debug("Pipeline configurations found: %s" % pcs)
 
         # We'll need to pass up the config names in order along with a dict of
         # pc_name => commands.
@@ -252,6 +254,8 @@ class ShotgunAPI(object):
         config_data = dict()
 
         for pc in pcs:
+            self.logger.debug("Processing config: %s" % pc)
+
             # The hash that acts as the key we'll use to look up our cached
             # data will be based on the entity type and the pipeline config's
             # descriptor uri. We can get the descriptor from the toolkit
@@ -259,6 +263,8 @@ class ShotgunAPI(object):
             # to the core hook that computes the hash.
             manager.pipeline_configuration = pc["id"]
             pc_descriptor = manager.resolve_descriptor(project_entity)
+
+            self.logger.debug("Resolved config descriptor: %s" % pc_descriptor)
             pc_key = pc_descriptor.get_uri()
 
             pc_data = dict()

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -223,7 +223,8 @@ class ShotgunAPI(object):
             self.host.reply(dict(retcode=constants.UNSUPPORTED_ENTITY_TYPE))
             return
 
-        manager = sgtk.bootstrap.ToolkitManager(allow_config_overrides=False)
+        manager = sgtk.bootstrap.ToolkitManager()
+        manager.allow_config_overrides = False
         manager.base_configuration = constants.BASE_CONFIG_URI
         pcs = self._get_pipeline_configurations(
             manager,

--- a/python/tk_framework_desktopserver/shotgun/constants.py
+++ b/python/tk_framework_desktopserver/shotgun/constants.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+
+# RPC return codes.
+SUCCESSFUL_LOOKUP = 0
+UNSUPPORTED_ENTITY_TYPE = 2
+CACHING_ERROR = 3
+COMMAND_SUCCEEDED = 0
+COMMAND_FAILED = 1
+
+# Pipeline configurations.
+OVERRIDE_CONFIG_PATH = os.environ.get("TK_BOOTSTRAP_CONFIG_OVERRIDE")
+
+if OVERRIDE_CONFIG_PATH is not None:
+    BASE_CONFIG_URI = "sgtk:descriptor:dev?path=%s" % OVERRIDE_CONFIG_PATH
+else:
+    BASE_CONFIG_URI = "sgtk:descriptor:app_store?name=tk-config-basic"

--- a/python/tk_framework_desktopserver/shotgun/constants.py
+++ b/python/tk_framework_desktopserver/shotgun/constants.py
@@ -8,6 +8,8 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+# Constants here are in use in api_v2. The legacy api_v1 does not currently
+# make use of them.
 import os
 
 # RPC return codes.
@@ -24,3 +26,5 @@ if OVERRIDE_CONFIG_PATH is not None:
     BASE_CONFIG_URI = "sgtk:descriptor:dev?path=%s" % OVERRIDE_CONFIG_PATH
 else:
     BASE_CONFIG_URI = "sgtk:descriptor:app_store?name=tk-config-basic"
+
+ENGINE_NAME = "tk-shotgun"

--- a/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
@@ -21,8 +21,8 @@ def cache(cache_file, data, base_configuration, hash_data, engine_name):
     project_entity = dict(id=data["project_id"], type="Project")
 
     # Setup the bootstrap manager.
-    toolkit_mgr = sgtk.bootstrap.ToolkitManager()
-    toolkit_mgr.plugin_id = "basic.shotgun.cache"
+    toolkit_mgr = sgtk.bootstrap.ToolkitManager(allow_config_overrides=False)
+    toolkit_mgr.plugin_id = "basic.shotgun"
     toolkit_mgr.base_configuration = base_configuration
 
     pcs = toolkit_mgr.get_pipeline_configurations(
@@ -35,15 +35,12 @@ def cache(cache_file, data, base_configuration, hash_data, engine_name):
 
         toolkit_mgr.pipeline_configuration = pc["id"]
         pc_descriptor = toolkit_mgr.resolve_descriptor(project_entity)
-        pc_path = pc_descriptor.get_path()
+        engine = toolkit_mgr.bootstrap_engine(engine_name, entity=entity)
 
-        if glob.glob(os.path.join(pc_path, "config", "env", "shotgun_*.yml")):
-            # Legacy case where there are shotgun_*.yml environment files.
-            engine = toolkit_mgr.bootstrap_legacy_shotgun_engine(entity)
-        else:
-            engine = toolkit_mgr.bootstrap_engine(engine_name, entity=entity)
-
+        engine.logger.debug("Engine %s started using entity %s" % (engine, entity))
+        engine.logger.debug("Config descriptor: %s" % pc_descriptor)
         engine.logger.debug("Processing engine commands...")
+
         commands = []
 
         for cmd_name, data in engine.commands.iteritems():

--- a/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
@@ -10,6 +10,8 @@
 
 import sys
 import cPickle
+import glob
+import os
 
 def cache(cache_file, data, base_configuration, hash_data, engine_name):
     import sqlite3
@@ -32,8 +34,14 @@ def cache(cache_file, data, base_configuration, hash_data, engine_name):
         contents_hash = hash_data[pc["id"]]["contents_hash"]
 
         toolkit_mgr.pipeline_configuration = pc["id"]
-        engine = toolkit_mgr.bootstrap_engine(engine_name, entity=entity)
         pc_descriptor = toolkit_mgr.resolve_descriptor(project_entity)
+        pc_path = pc_descriptor.get_path()
+
+        if glob.glob(os.path.join(pc_path, "config", "env", "shotgun_*.yml")):
+            # Legacy case where there are shotgun_*.yml environment files.
+            engine = toolkit_mgr.bootstrap_legacy_shotgun_engine(entity)
+        else:
+            engine = toolkit_mgr.bootstrap_engine(engine_name, entity=entity)
 
         engine.logger.debug("Processing engine commands...")
         commands = []

--- a/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
@@ -21,7 +21,8 @@ def cache(cache_file, data, base_configuration, hash_data, engine_name):
     project_entity = dict(id=data["project_id"], type="Project")
 
     # Setup the bootstrap manager.
-    toolkit_mgr = sgtk.bootstrap.ToolkitManager(allow_config_overrides=False)
+    toolkit_mgr = sgtk.bootstrap.ToolkitManager()
+    toolkit_mgr.allow_config_overrides = False
     toolkit_mgr.plugin_id = "basic.shotgun"
     toolkit_mgr.base_configuration = base_configuration
 

--- a/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
@@ -19,7 +19,7 @@ def execute(config, project, name, entities, base_configuration, engine_name):
 
     # Setup the bootstrap manager.
     toolkit_mgr = sgtk.bootstrap.ToolkitManager()
-    toolkit_mgr.plugin_id = "basic.shotgun.execute"
+    toolkit_mgr.plugin_id = "basic.shotgun"
     toolkit_mgr.base_configuration = base_configuration
 
     if config:

--- a/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
@@ -19,6 +19,7 @@ def execute(config, project, name, entities, base_configuration, engine_name):
 
     # Setup the bootstrap manager.
     toolkit_mgr = sgtk.bootstrap.ToolkitManager()
+    toolkit_mgr.allow_config_overrides = False
     toolkit_mgr.plugin_id = "basic.shotgun"
     toolkit_mgr.base_configuration = base_configuration
 


### PR DESCRIPTION
 Also fixes incorrect usage of the TK_BOOTSTRAP_CONFIG_OVERRIDE environment variable.

In the event that the caching process finds shotgun_*.yml files in the config, it will make use of those rather than bootstrapping into the conventional environments. The intent is to maintain backwards compatibility.