### PR TITLE
For #41991: Adds support for remaining "special" toolkit action manu commands.

### DIFF
--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -144,7 +144,7 @@ class ShotgunAPI(object):
         python_exe = sgtk.get_python_interpreter_for_config(
             self._engine.sgtk.pipeline_configuration.get_path(),
         )
-        logger.debug("Python executable: %s" % python_exe)
+        logger.debug("Python executable: %s", python_exe)
 
         try:
             kwargs = self._get_subprocess_kwargs()
@@ -279,7 +279,7 @@ class ShotgunAPI(object):
                                 entities=entities,
                             )
 
-                            logger.debug("Actions found in cache: %s" % actions)
+                            logger.debug("Actions found in cache: %s", actions)
 
                             all_actions[pipeline_config["name"]] = dict(
                                 actions=self._filter_by_project(
@@ -289,7 +289,7 @@ class ShotgunAPI(object):
                                 ),
                                 config=pipeline_config,
                             )
-                            logger.debug("Actions after project filtering: %s" % actions)
+                            logger.debug("Actions after project filtering: %s", actions)
                         else:
                             # The hashes didn't match, so we know we need to
                             # re-cache. Once we do that, we can just call the
@@ -367,7 +367,7 @@ class ShotgunAPI(object):
             "cache_commands.py"
         )
 
-        logger.debug("Executing script: %s" % script)
+        logger.debug("Executing script: %s", script)
 
         # We'll need the Python executable when we shell out. We can't
         # rely on sys.executable, because that's going to be the Desktop
@@ -376,7 +376,7 @@ class ShotgunAPI(object):
         python_exe = sgtk.get_python_interpreter_for_config(
             self._engine.sgtk.pipeline_configuration.get_path(),
         )
-        logger.debug("Python executable: %s" % python_exe)
+        logger.debug("Python executable: %s", python_exe)
 
         arg_config_data = dict(
             lookup_hash = config_data["lookup_hash"],
@@ -494,7 +494,7 @@ class ShotgunAPI(object):
             for sw in associated_sw:
                 for sw_project in sw.get("projects", []):
                     if sw_project["id"] != project["id"]:
-                        logger.debug("Action %s filtered out due to SW entity projects." % action)
+                        logger.debug("Action %s filtered out due to SW entity projects.", action)
                         filtered.append(action)
                         break
                 if action in filtered:
@@ -651,7 +651,7 @@ class ShotgunAPI(object):
             pipeline_configs = pipeline_configs or [dict(id=None, name="Primary")]
 
             for pipeline_config in pipeline_configs:
-                logger.debug("Processing config: %s" % pipeline_config)
+                logger.debug("Processing config: %s", pipeline_config)
 
                 # The hash that acts as the key we'll use to look up our cached
                 # data will be based on the entity type and the pipeline config's
@@ -667,7 +667,7 @@ class ShotgunAPI(object):
                     logger.debug(str(exc))
                     continue
 
-                logger.debug("Resolved config descriptor: %r" % pc_descriptor)
+                logger.debug("Resolved config descriptor: %r", pc_descriptor)
                 pc_key = pc_descriptor.get_uri()
 
                 pc_data = dict()
@@ -725,7 +725,7 @@ class ShotgunAPI(object):
             )
         else:
             logger.debug(
-                "Cached PipelineConfiguration entities found for %s" % self._wss_key
+                "Cached PipelineConfiguration entities found for %s", self._wss_key
             )
 
         return pc_data[project["id"]]
@@ -755,7 +755,7 @@ class ShotgunAPI(object):
                 entities = self._engine.shotgun.find(**spec)
                 self.WSS_KEY_CACHE[self._wss_key]["site_state_data"].extend(entities)
         else:
-            logger.debug("Cached site state data found for %s" % self._wss_key)
+            logger.debug("Cached site state data found for %s", self._wss_key)
 
         return self.WSS_KEY_CACHE[self._wss_key]["site_state_data"]
 
@@ -780,7 +780,7 @@ class ShotgunAPI(object):
                 fields=self._engine.shotgun.schema_field_read("Software").keys(),
             )
         else:
-            logger.debug("Cached software entities found for %s" % self._wss_key)
+            logger.debug("Cached software entities found for %s", self._wss_key)
 
         return self.WSS_KEY_CACHE[self._wss_key]["software_entities"]
 
@@ -822,11 +822,11 @@ class ShotgunAPI(object):
 
         for command in commands:
             if command["app_name"] is not None:
-                logger.debug("Keeping command %s -- it has an associated app." % command)
+                logger.debug("Keeping command %s -- it has an associated app.", command)
                 filtered.append(command)
             else:
                 logger.debug(
-                    "Command %s filtered out for browser integration." % command
+                    "Command %s filtered out for browser integration.", command
                 )
 
         return self._engine.sgtk.execute_core_hook_method(

--- a/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
@@ -52,7 +52,7 @@ def bootstrap(data, base_configuration, engine_name, config_data):
     manager.pipeline_configuration = config_data["entity"]["id"]
 
     engine = manager.bootstrap_engine(engine_name, entity=entity)
-    logger.debug("Engine %s started using entity %s" % (engine, entity))
+    logger.debug("Engine %s started using entity %s", engine, entity)
 
     return engine
 
@@ -113,7 +113,7 @@ def cache(cache_file, data, base_configuration, engine_name, config_data):
         logger.debug("Not registering core and app update commands.")
 
     for cmd_name, data in engine.commands.iteritems():
-        logger.debug("Processing command: %s" % cmd_name)
+        logger.debug("Processing command: %s", cmd_name)
         props = data["properties"]
         app = props.get("app")
 

--- a/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
@@ -15,6 +15,11 @@ import os
 import sqlite3
 import contextlib
 
+CORE_INFO_COMMAND = "__core_info"
+UPGRADE_CHECK_COMMAND = "__upgrade_check"
+
+LOGGER_NAME = "wss2.cache_commands"
+
 def bootstrap(data, base_configuration, engine_name, config_data):
     """
     Bootstraps into sgtk and returns the resulting engine instance.
@@ -34,6 +39,8 @@ def bootstrap(data, base_configuration, engine_name, config_data):
     # The local import of sgtk ensures that it occurs after sys.path is set
     # to what the server sent over.
     import sgtk
+    logger = sgtk.LogManager.get_logger(LOGGER_NAME)
+    logger.debug("Preparing ToolkitManager for bootstrap.")
 
     entity = dict(type=data["entity_type"], id=data["entity_id"])
 
@@ -45,7 +52,7 @@ def bootstrap(data, base_configuration, engine_name, config_data):
     manager.pipeline_configuration = config_data["entity"]["id"]
 
     engine = manager.bootstrap_engine(engine_name, entity=entity)
-    engine.logger.debug("Engine %s started using entity %s" % (engine, entity))
+    logger.debug("Engine %s started using entity %s" % (engine, entity))
 
     return engine
 
@@ -66,14 +73,47 @@ def cache(cache_file, data, base_configuration, engine_name, config_data):
         "contents_hash" keys.
     """
     engine = bootstrap(data, base_configuration, engine_name, config_data)
+
+    import sgtk
+    logger = sgtk.LogManager.get_logger(LOGGER_NAME)
+
+    logger.debug("Raw payload from client: %s", data)
+
     lookup_hash = config_data["lookup_hash"]
     contents_hash = config_data["contents_hash"]
 
-    engine.logger.debug("Processing engine commands...")
+    logger.debug("Processing engine commands...")
     commands = []
 
+    # Slug in the "special" commands that aren't associated with registered
+    # engine commands.
+    if data["entity_type"].lower() == "project":
+        logger.debug("Registering core and app upgrade commands...")
+        commands.extend([
+            dict(
+                name="__core_info",
+                title="Check for Core Upgrades...",
+                deny_permissions=["Artist"],
+                app_name="__builtin",
+                group=None,
+                group_default=False,
+                engine_name="tk-shotgun",
+            ),
+            dict(
+                name="__upgrade_check",
+                title="Check for App Upgrades...",
+                deny_permissions=["Artist"],
+                app_name="__builtin",
+                group=None,
+                group_default=False,
+                engine_name="tk-shotgun",
+            ),
+        ])
+    else:
+        logger.debug("Not registering core and app update commands.")
+
     for cmd_name, data in engine.commands.iteritems():
-        engine.logger.debug("Processing command: %s" % cmd_name)
+        logger.debug("Processing command: %s" % cmd_name)
         props = data["properties"]
         app = props.get("app")
 
@@ -98,69 +138,70 @@ def cache(cache_file, data, base_configuration, engine_name, config_data):
             ),
         )
 
-        engine.logger.debug("Engine commands processed.")
-        engine.logger.debug("Inserting commands into cache...")
+    logger.debug("Engine commands processed.")
 
-        # Connect to the database and get the hashes we need to include in
-        # the insert. Each of the lookups call out to the browser_integration
-        # core hook.
-        with sqlite3.connect(cache_file) as connection:
-            # This is to handle unicode properly - make sure that sqlite returns 
-            # str objects for TEXT fields rather than unicode. Note that any unicode
-            # objects that are passed into the database will be automatically
-            # converted to UTF-8 strs, so this text_factory guarantees that any character
-            # representation will work for any language, as long as data is either input
-            # as UTF-8 (byte string) or unicode. And in the latter case, the returned data
-            # will always be unicode.
-            connection.text_factory = str
-            cursor = connection.cursor()
+    # Connect to the database and get the hashes we need to include in
+    # the insert. Each of the lookups call out to the browser_integration
+    # core hook.
+    with sqlite3.connect(cache_file) as connection:
+        logger.debug("Inserting commands into cache...")
 
-            # First, let's make sure that the database is actually setup with
-            # the table we're expecting. If it isn't, then we can do that here.
-            with contextlib.closing(connection.cursor()) as c:
-                # Get a list of tables in the current database.
-                ret = c.execute("SELECT name FROM main.sqlite_master WHERE type='table';")
-                table_names = [x[0] for x in ret.fetchall()]
+        # This is to handle unicode properly - make sure that sqlite returns 
+        # str objects for TEXT fields rather than unicode. Note that any unicode
+        # objects that are passed into the database will be automatically
+        # converted to UTF-8 strs, so this text_factory guarantees that any character
+        # representation will work for any language, as long as data is either input
+        # as UTF-8 (byte string) or unicode. And in the latter case, the returned data
+        # will always be unicode.
+        connection.text_factory = str
+        cursor = connection.cursor()
 
-                if not table_names:
-                    engine.logger.debug("Creating schema in sqlite db.")
+        # First, let's make sure that the database is actually setup with
+        # the table we're expecting. If it isn't, then we can do that here.
+        with contextlib.closing(connection.cursor()) as c:
+            # Get a list of tables in the current database.
+            ret = c.execute("SELECT name FROM main.sqlite_master WHERE type='table';")
+            table_names = [x[0] for x in ret.fetchall()]
 
-                    # We have a brand new database. Create all tables and indices.
-                    cursor.executescript("""
-                        CREATE TABLE engine_commands (lookup_hash text, contents_hash text, commands blob);
-                    """)
+            if not table_names:
+                logger.debug("Creating schema in sqlite db.")
 
-                    connection.commit()
+                # We have a brand new database. Create all tables and indices.
+                cursor.executescript("""
+                    CREATE TABLE engine_commands (lookup_hash text, contents_hash text, commands blob);
+                """)
 
-            commands_blob = sqlite3.Binary(
-                cPickle.dumps(commands, cPickle.HIGHEST_PROTOCOL)
+                connection.commit()
+
+        commands_blob = sqlite3.Binary(
+            cPickle.dumps(commands, cPickle.HIGHEST_PROTOCOL)
+        )
+
+        # Since we're likely to be updating out-of-date cached data more
+        # often than we're going to be inserting new rows into the cache,
+        # we'll try an update first. If no rows were affected by the update,
+        # we move on to an insert.
+        cursor.execute(
+            "UPDATE engine_commands SET contents_hash=?, commands=? WHERE lookup_hash=?",
+            (contents_hash, commands_blob, lookup_hash)
+        )
+
+        if cursor.rowcount == 0:
+            logger.debug(
+                "Update did not result in any rows altered, inserting..."
             )
-
-            # Since we're likely to be updating out-of-date cached data more
-            # often than we're going to be inserting new rows into the cache,
-            # we'll try an update first. If no rows were affected by the update,
-            # we move on to an insert.
             cursor.execute(
-                "UPDATE engine_commands SET contents_hash=?, commands=? WHERE lookup_hash=?",
-                (contents_hash, commands_blob, lookup_hash)
+                "INSERT INTO engine_commands VALUES (?, ?, ?)", (
+                    lookup_hash,
+                    contents_hash,
+                    commands_blob,
+                )
             )
-
-            if cursor.rowcount == 0:
-                engine.logger.debug(
-                    "Update did not result in any rows altered, inserting..."
-                )
-                cursor.execute(
-                    "INSERT INTO engine_commands VALUES (?, ?, ?)", (
-                        lookup_hash,
-                        contents_hash,
-                        commands_blob,
-                    )
-                )
 
         # Tear down the engine. This is both good practice before we exit
         # this process, but also necessary if there are multiple pipeline
         # configs that we're iterating over.
-        engine.logger.debug("Shutting down engine...")
+        logger.debug("Shutting down engine...")
         engine.destroy()
 
 if __name__ == "__main__":

--- a/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
@@ -11,6 +11,154 @@
 import sys
 import cPickle
 import os
+import logging
+
+# Special, non-engine commands that we'll need to handle ourselves.
+CORE_INFO_COMMAND = "__core_info"
+UPGRADE_CHECK_COMMAND = "__upgrade_check"
+
+# We can't have a global logger instance, because we can't import sgtk
+# in the global scope, but we can go ahead and define the logger name
+# to be used throughout the script.
+LOGGER_NAME = "wss2.execute_command"
+
+def app_upgrade_info(engine):
+    """
+    Logs a message for the user that tells them how to check for app updates.
+    This is provided for legacy purposes for "classic" SGTK setups.
+
+    :param engine: The currently-running engine instance.
+    """
+    import sgtk
+    logger = sgtk.LogManager.get_logger(LOGGER_NAME)
+
+    code_css_block = "display: block; padding: 0.5em 1em; border: 1px solid #bebab0; background: #faf8f0;"
+
+    logger.info(
+        "In order to check if your installed apps and engines are up to date, "
+        "you can run the following command in a console:"
+    )
+
+    logger.info("")
+    config_root = engine.sgtk.pipeline_configuration.get_path()
+
+    if sys.platform == "win32":
+        tank_cmd = os.path.join(config_root, "tank.bat")
+    else:
+        tank_cmd = os.path.join(config_root, "tank")
+
+    logger.info("<code style='%s'>%s updates</code>" % (code_css_block, tank_cmd))
+    logger.info("")
+
+def core_info(engine):
+    """
+    Builds and logs a report on whether the currently-installed core is up to
+    data with what's in the app_store.
+
+    :param engine: The currently-running engine instance.
+    """
+    import sgtk
+    from sgtk.commands.core_upgrade import TankCoreUpdater
+    logger = sgtk.LogManager.get_logger(LOGGER_NAME)
+
+    code_css_block = "display: block; padding: 0.5em 1em; border: 1px solid #bebab0; background: #faf8f0;"
+
+    # Create an upgrader instance that we can query if the install is up to date.
+    installer = TankCoreUpdater(
+        engine.sgtk.pipeline_configuration.get_install_location(),
+        logger,
+    )
+
+    cv = installer.get_current_version_number()
+    lv = installer.get_update_version_number()
+
+    logger.info(
+        "You are currently running version %s of the Shotgun Pipeline Toolkit." % cv
+    )
+
+    if not engine.sgtk.pipeline_configuration.is_localized():
+        logger.info("")
+        logger.info(
+            "Your core API is located in <code>%s</code> and is shared with other "
+            "projects." % install_root
+        )
+
+    logger.info("")
+    status = installer.get_update_status()
+
+    if status == TankCoreUpdater.UP_TO_DATE:
+        logger.info(
+            "<b>You are up to date! There is no need to update the Toolkit "
+            "Core API at this time!</b>"
+        )
+    elif status == TankCoreUpdater.UPDATE_BLOCKED_BY_SG:
+        req_sg = installer.get_required_sg_version_for_update()
+        logger.warning(
+            "<b>A new version (%s) of the core API is available however "
+            "it requires a more recent version (%s) of Shotgun!</b>" % (lv, req_sg)
+        )
+    elif status == TankCoreUpdater.UPDATE_POSSIBLE:
+        (summary, url) = installer.get_release_notes()
+
+        logger.info("<b>A new version of the Toolkit API (%s) is available!</b>" % lv)
+        logger.info("")
+        logger.info(
+            "<b>Change Summary:</b> %s <a href='%s' target=_new>"
+            "Click for detailed Release Notes</a>" % (summary, url)
+        )
+        logger.info("")
+        logger.info("In order to upgrade, execute the following command in a shell:")
+        logger.info("")
+
+        if sys.platform == "win32":
+            tank_cmd = os.path.join(install_root, "tank.bat")
+        else:
+            tank_cmd = os.path.join(install_root, "tank")
+
+        logger.info("<code style='%s'>%s core</code>" % (code_css_block, tank_cmd))
+        logger.info("")
+    else:
+        raise sgtk.TankError("Unknown Upgrade state!")
+
+def bootstrap(config, base_configuration, entity, engine_name):
+    """
+    Executes an engine command in the desired environment.
+
+    :param dict config: The pipeline configuration entity.
+    :param dict entity: The entity to give to the bootstrap manager when
+        bootstrapping the engine.
+    :param str base_configuration: The desired base pipeline configuration's
+        uri.
+    :param str engine_name: The name of the engine to bootstrap into. This
+        is most likely going to be "tk-shotgun"
+
+    :returns: The bootstrapped engine instance.
+    """
+    # The local import of sgtk ensures that it occurs after sys.path is set
+    # to what the server sent over.
+    import sgtk
+    logger = sgtk.LogManager.get_logger(LOGGER_NAME)
+
+    # Setup the bootstrap manager.
+    logger.debug("Preparing ToolkitManager for bootstrap.")
+    manager = sgtk.bootstrap.ToolkitManager()
+
+    # Not allowing config resolution to be overridden by environment
+    # variables. This is here mostly for dev environment purposes, as
+    # we'll use the env var to point to a dev config, but we don't
+    # want that to then override everything else, like PipelineConfiguration
+    # entities associated with the project.
+    manager.allow_config_overrides = False
+    manager.plugin_id = "basic.shotgun"
+    manager.base_configuration = base_configuration
+
+    if config:
+        manager.pipeline_configuration = config.get("id")
+
+    engine = manager.bootstrap_engine(engine_name, entity=entity)
+    logger.debug("Engine %s started using entity %s" % (engine, entity))
+
+    return engine
 
 def execute(config, project, name, entities, base_configuration, engine_name):
     """
@@ -18,6 +166,7 @@ def execute(config, project, name, entities, base_configuration, engine_name):
 
     :param dict config: The pipeline configuration entity.
     :param dict project: The project entity.
+    :param str name: The name of the engine command to execute.
     :param list entities: The list of entities selected in the web UI when the
         command action was triggered.
     :param str base_configuration: The desired base pipeline configuration's
@@ -25,19 +174,6 @@ def execute(config, project, name, entities, base_configuration, engine_name):
     :param str engine_name: The name of the engine to bootstrap into. This
         is most likely going to be "tk-shotgun"
     """
-    # The local import of sgtk ensures that it occurs after sys.path is set
-    # to what the server sent over.
-    import sgtk
-
-    # Setup the bootstrap manager.
-    toolkit_mgr = sgtk.bootstrap.ToolkitManager()
-    toolkit_mgr.allow_config_overrides = False
-    toolkit_mgr.plugin_id = "basic.shotgun"
-    toolkit_mgr.base_configuration = base_configuration
-
-    if config:
-        toolkit_mgr.pipeline_configuration = config.get("id")
-
     # We need a single, representative entity when we bootstrap. The fact that
     # we might have gotten multiple entities from the client due to a
     # multiselection is only relevant later on when we're actually executing
@@ -47,7 +183,23 @@ def execute(config, project, name, entities, base_configuration, engine_name):
     else:
         entity = project
 
-    engine = toolkit_mgr.bootstrap_engine(engine_name, entity=entity)
+    engine = bootstrap(config, base_configuration, entity, engine_name)
+
+    import sgtk
+    logger = sgtk.LogManager.get_logger(LOGGER_NAME)
+
+    # Handle the "special" commands that aren't tied to any registered engine
+    # commands.
+    if name == CORE_INFO_COMMAND:
+        core_info(engine)
+        sys.exit(0)
+    elif name == UPGRADE_CHECK_COMMAND:
+        app_upgrade_info(engine)
+        sys.exit(0)
+
+    # Import sgtk here after the bootstrap. That will ensure that we get the
+    # core that was swapped in during the bootstrap.
+    import sgtk
 
     # We need to make sure that sgtk is accessible to any process that the
     # command execution spawns. We'll look up the path to the pipeline
@@ -68,8 +220,8 @@ def execute(config, project, name, entities, base_configuration, engine_name):
 
     if not command:
         msg = "Unable to find engine command: %s" % name
-        engine.logger.error(msg)
-        raise RuntimeError(msg)
+        logger.error(msg)
+        raise sgtk.TankError(msg)
 
     # We need to know whether this command is allowed to be run when multiple
     # entities are selected. We can look for the special flag in the command's

--- a/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
@@ -156,7 +156,7 @@ def bootstrap(config, base_configuration, entity, engine_name):
         manager.pipeline_configuration = config.get("id")
 
     engine = manager.bootstrap_engine(engine_name, entity=entity)
-    logger.debug("Engine %s started using entity %s" % (engine, entity))
+    logger.debug("Engine %s started using entity %s", (engine, entity))
 
     return engine
 


### PR DESCRIPTION
* Adds support for "Check for Core Upgrades..." menu action.
* Adds support for "Check for App Upgrades..." menu action.
* Revamps logging to bring it into line with 0.18 standards.
* Resolves bug related to how config_data is cached in memory. Previously, this cache was not stored per unique entity type, which resulted in cross pollination of engine commands into incorrect entity types.
* Resolves a bug in the cache_commands script that resulted in one cache update per engine command...which is obviously not correct.