### PR TITLE
For #42066: Gets config descriptors in bulk from ToolkitManager.

### DIFF
--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -677,7 +677,7 @@ class ShotgunAPI(object):
 
                 if pc_descriptor is None:
                     logger.warning(
-                        "Unable to resolve config descriptor, skipping: %s",
+                        "Unable to resolve config descriptor, skipping: %r",
                         pipeline_config,
                     )
                     continue

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -391,10 +391,6 @@ class ShotgunAPI(object):
             entity=config_data["entity"],
         )
 
-        # If we have a descriptor, we don't want to pickle that. It's not
-        # needed in either the caching or execution scripts.
-        del arg_config_data["entity"]["descriptor"]
-
         args_file = self._get_arguments_file(
             dict(
                 cache_file=self._cache_path,
@@ -712,6 +708,9 @@ class ShotgunAPI(object):
             else:
                 cache["config_data"] = config_data
 
+        # We'll deepcopy the data before returning it. That will ensure that
+        # any destructive operations on the contents won't bubble up to the
+        # cache.
         return copy.deepcopy(cache["config_data"][entity_type])
 
     def _get_pipeline_configurations(self, manager, project):
@@ -747,6 +746,9 @@ class ShotgunAPI(object):
                 "Cached PipelineConfiguration entities found for %s", self._wss_key
             )
 
+        # We'll deepcopy the data before returning it. That will ensure that
+        # any destructive operations on the contents won't bubble up to the
+        # cache.
         return copy.deepcopy(pc_data[project["id"]])
 
     def _get_site_state_data(self):
@@ -776,6 +778,9 @@ class ShotgunAPI(object):
         else:
             logger.debug("Cached site state data found for %s", self._wss_key)
 
+        # We'll deepcopy the data before returning it. That will ensure that
+        # any destructive operations on the contents won't bubble up to the
+        # cache.
         return copy.deepcopy(self.WSS_KEY_CACHE[self._wss_key]["site_state_data"])
 
     def _get_software_entities(self):
@@ -801,6 +806,9 @@ class ShotgunAPI(object):
         else:
             logger.debug("Cached software entities found for %s", self._wss_key)
 
+        # We'll deepcopy the data before returning it. That will ensure that
+        # any destructive operations on the contents won't bubble up to the
+        # cache.
         return copy.deepcopy(self.WSS_KEY_CACHE[self._wss_key]["software_entities"])
 
     def _get_subprocess_kwargs(self):

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -242,10 +242,7 @@ class ShotgunAPI(object):
 
                 # Since the config entity is going to be passed up as part of the
                 # reply to the client, we need to filter out the descriptor object.
-                # It's neither useful to the client, nor json encodable. We're
-                # copying the dict first, since the original is stored in an
-                # in-memory cache and is likely to be reused.
-                pipeline_config = copy.copy(pipeline_config)
+                # It's neither useful to the client, nor json encodable.
                 del pipeline_config["descriptor"]
 
                 lookup_hash = pc_data["lookup_hash"]
@@ -391,13 +388,12 @@ class ShotgunAPI(object):
         arg_config_data = dict(
             lookup_hash = config_data["lookup_hash"],
             contents_hash=config_data["contents_hash"],
-            entity=copy.copy(config_data["entity"]),
+            entity=config_data["entity"],
         )
 
         # If we have a descriptor, we don't want to pickle that. It's not
         # needed in either the caching or execution scripts.
-        if "descriptor" in arg_config_data["entity"]:
-            del arg_config_data["entity"]["descriptor"]
+        del arg_config_data["entity"]["descriptor"]
 
         args_file = self._get_arguments_file(
             dict(
@@ -716,7 +712,7 @@ class ShotgunAPI(object):
             else:
                 cache["config_data"] = config_data
 
-        return cache["config_data"][entity_type]
+        return copy.deepcopy(cache["config_data"][entity_type])
 
     def _get_pipeline_configurations(self, manager, project):
         """
@@ -751,7 +747,7 @@ class ShotgunAPI(object):
                 "Cached PipelineConfiguration entities found for %s", self._wss_key
             )
 
-        return pc_data[project["id"]]
+        return copy.deepcopy(pc_data[project["id"]])
 
     def _get_site_state_data(self):
         """
@@ -780,7 +776,7 @@ class ShotgunAPI(object):
         else:
             logger.debug("Cached site state data found for %s", self._wss_key)
 
-        return self.WSS_KEY_CACHE[self._wss_key]["site_state_data"]
+        return copy.deepcopy(self.WSS_KEY_CACHE[self._wss_key]["site_state_data"])
 
     def _get_software_entities(self):
         """
@@ -805,7 +801,7 @@ class ShotgunAPI(object):
         else:
             logger.debug("Cached software entities found for %s", self._wss_key)
 
-        return self.WSS_KEY_CACHE[self._wss_key]["software_entities"]
+        return copy.deepcopy(self.WSS_KEY_CACHE[self._wss_key]["software_entities"])
 
     def _get_subprocess_kwargs(self):
         """

--- a/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
@@ -156,7 +156,7 @@ def bootstrap(config, base_configuration, entity, engine_name):
         manager.pipeline_configuration = config.get("id")
 
     engine = manager.bootstrap_engine(engine_name, entity=entity)
-    logger.debug("Engine %s started using entity %s", (engine, entity))
+    logger.debug("Engine %s started using entity %s", engine, entity)
 
     return engine
 


### PR DESCRIPTION
Config descriptors are no longer queried one at a time. They come in bulk from ToolkitManager by way of `get_pipeline_configurations()`.