### PR TITLE
For #42178, websocket callbacks

### DIFF
--- a/app/config.ini.example
+++ b/app/config.ini.example
@@ -30,8 +30,3 @@ low_level_debug=0
 # port.
 #
 port=9000
-
-# List of clients whitelisted to access this server. Use this when you have a
-# local server. If not specified, defaults to *.shotgunstudio.com.
-#
-whitelist=*.shotgunstudio.com

--- a/framework.py
+++ b/framework.py
@@ -34,7 +34,7 @@ class DesktopserverFramework(sgtk.platform.Framework):
 
     ##########################################################################################
     # init and destroy
-    def launch_desktop_server(self, user):
+    def launch_desktop_server(self, host, user_id):
         """
         Initializes the desktop server.
         """
@@ -74,7 +74,8 @@ class DesktopserverFramework(sgtk.platform.Framework):
 
             self._server = self._tk_framework_desktopserver.Server(
                 keys_path=self._settings.certificate_folder,
-                user=user,
+                host=host,
+                user_id=user_id,
                 low_level_debug=self._settings.low_level_debug,
                 port=self._settings.port
             )

--- a/framework.py
+++ b/framework.py
@@ -27,10 +27,10 @@ class DesktopserverFramework(sgtk.platform.Framework):
         self._notifier = self.Notifier()
 
     def add_invalid_site_callback(self, cb):
-        self._server.notifier.wrong_site.connect(cb)
+        self._server.different_site_requested.wrong_site.connect(cb, type=QtCore.Qt.QueuedConnection)
 
     def add_invalid_user_callback(self, cb):
-        self._server.notifier.wrong_user.connect(cb)
+        self._server.different_user_requested.connect(cb, type=QtCore.Qt.QueuedConnection)
 
     ##########################################################################################
     # init and destroy

--- a/framework.py
+++ b/framework.py
@@ -26,9 +26,9 @@ class DesktopserverFramework(sgtk.platform.Framework):
         self._settings = None
         self._tk_framework_desktopserver = None
 
-    def add_diffrent_user_requested_callback(self, cb):
+    def add_different_user_requested_callback(self, cb):
         """
-        Registers a callback for know when a different user or site is making browser integration requests.
+        Registers a callback to know when a different user or site is making browser integration requests.
         The caller is not waiting for the callback to return.
 
         :param function cb: Callback of the form:
@@ -50,6 +50,13 @@ class DesktopserverFramework(sgtk.platform.Framework):
     def launch_desktop_server(self, host, user_id):
         """
         Initializes the desktop server.
+
+        The server actually supports two protocols, named v1 and v2. v1 can be used to process requests from any
+        users from any sites, while v2 can only be used to process requests from the currently authenticated
+        user.
+
+        :param str host: Host for which we desire to answer requests.
+        :param int user_id: Id of the user for which we desire to answer requests.
         """
         self._tk_framework_desktopserver = self.import_module("tk_framework_desktopserver")
 

--- a/framework.py
+++ b/framework.py
@@ -19,12 +19,18 @@ class DesktopserverFramework(sgtk.platform.Framework):
     """
     Provides browser integration.
     """
-
     def __init__(self, *args, **kwargs):
         super(DesktopserverFramework, self).__init__(*args, **kwargs)
         self._server = None
         self._settings = None
         self._tk_framework_desktopserver = None
+        self._notifier = self.Notifier()
+
+    def add_invalid_site_callback(self, cb):
+        self._server.notifier.wrong_site.connect(cb)
+
+    def add_invalid_user_callback(self, cb):
+        self._server.notifier.wrong_user.connect(cb)
 
     ##########################################################################################
     # init and destroy

--- a/framework.py
+++ b/framework.py
@@ -26,9 +26,15 @@ class DesktopserverFramework(sgtk.platform.Framework):
         self._settings = None
         self._tk_framework_desktopserver = None
 
+    def add_diffrent_user_requested_callback(self, cb):
+        # Lazy-init because engine is initialized after its frameworks, so QtCore is not initialized yet.
+        from sgtk.platform.qt import QtCore
+        if self._server:
+            self._server.notifier.different_user_requested.connect(cb, type=QtCore.Qt.QueuedConnection)
+
     ##########################################################################################
     # init and destroy
-    def launch_desktop_server(self):
+    def launch_desktop_server(self, user):
         """
         Initializes the desktop server.
         """
@@ -67,10 +73,10 @@ class DesktopserverFramework(sgtk.platform.Framework):
             self.__ensure_certificate_ready()
 
             self._server = self._tk_framework_desktopserver.Server(
-                port=self._settings.port,
+                keys_path=self._settings.certificate_folder,
+                user=user,
                 low_level_debug=self._settings.low_level_debug,
-                whitelist=self._settings.whitelist,
-                keys_path=self._settings.certificate_folder
+                port=self._settings.port
             )
 
             self._server.start()

--- a/framework.py
+++ b/framework.py
@@ -27,6 +27,19 @@ class DesktopserverFramework(sgtk.platform.Framework):
         self._tk_framework_desktopserver = None
 
     def add_diffrent_user_requested_callback(self, cb):
+        """
+        Registers a callback for know when a different user or site is making browser integration requests.
+        The caller is not waiting for the callback to return.
+
+        :param function cb: Callback of the form:
+            def callback(site, user_id):
+                '''
+                Called when the site or user is different than the current site or user.
+
+                :param str site: Url of the site the request is coming from.
+                :param int user_id: Id of the HumanUser who made the request.
+                '''
+        """
         # Lazy-init because engine is initialized after its frameworks, so QtCore is not initialized yet.
         from sgtk.platform.qt import QtCore
         if self._server:

--- a/framework.py
+++ b/framework.py
@@ -69,7 +69,6 @@ class DesktopserverFramework(sgtk.platform.Framework):
             self._server = self._tk_framework_desktopserver.Server(
                 port=self._settings.port,
                 low_level_debug=self._settings.low_level_debug,
-                whitelist=self._settings.whitelist,
                 keys_path=self._settings.certificate_folder
             )
 

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+print "olla"
+from . import tk_framework_desktopserver # noqa
+print "allo"

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -8,6 +8,4 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-print "olla"
 from . import tk_framework_desktopserver # noqa
-print "allo"

--- a/python/tk_framework_desktopserver/certificates.py
+++ b/python/tk_framework_desktopserver/certificates.py
@@ -274,7 +274,7 @@ class _WindowsCertificateHandler(_CertificateHandler):
 
         :returns: True on success, False on failure.
         """
-        success = self._check_call(
+        self._check_call(
             "registering the certificate",
             ("certutil", "-user", "-addstore", "root", self._cert_path.replace("/", "\\"))
         )

--- a/python/tk_framework_desktopserver/certificates.py
+++ b/python/tk_framework_desktopserver/certificates.py
@@ -17,6 +17,8 @@ from .errors import CertificateRegistrationError
 
 from OpenSSL import crypto
 
+logger = get_logger(__name__)
+
 
 class _CertificateHandler(object):
     """
@@ -27,7 +29,6 @@ class _CertificateHandler(object):
         """
         :param str certificate_folder: Path where the certificates will be written.
         """
-        self._logger = get_logger("certificates")
         self._cert_path = os.path.join(certificate_folder, "server.crt")
         self._key_path = os.path.join(certificate_folder, "server.key")
 
@@ -106,7 +107,7 @@ class _CertificateHandler(object):
 
         # Do not use popen.check_call because it won't redirect stderr to stdout properly
         # and it can't close stdin which causes issues in certain configurations on Windows.
-        self._logger.debug("%s: %s" % (ctx.capitalize(), cmd))
+        logger.debug("%s: %s" % (ctx.capitalize(), cmd))
         if sys.platform == "win32":
             # More on this Windows specific fix here: https://bugs.python.org/issue3905
             p = subprocess.Popen(
@@ -120,7 +121,7 @@ class _CertificateHandler(object):
         else:
             p = subprocess.Popen(cmd, stderr=subprocess.STDOUT, stdout=subprocess.PIPE, shell=True)
         stdout, _ = p.communicate()
-        self._logger.debug("Stdout:\n%s" % stdout)
+        logger.debug("Stdout:\n%s" % stdout)
         if p.returncode != 0:
             raise CertificateRegistrationError("There was a problem %s." % ctx)
         return stdout
@@ -207,13 +208,13 @@ class _LinuxCertificateHandler(_CertificateHandler):
 
         # Ensure that the Chrome certificate registry folder exists
         if not os.path.exists(self._PKI_DB_PATH):
-            self._logger.debug("Creating '%s'", self._PKI_DB_PATH)
+            logger.debug("Creating '%s'", self._PKI_DB_PATH)
             os.makedirs(self._PKI_DB_PATH)
 
         # If the Chrome certificate registry is empty, create it. If there is already a database in
         # there, the folder won't be empty.
         if not os.listdir(self._PKI_DB_PATH):
-            self._logger.debug("Initializing db at '%s'", self._PKI_DB_PATH)
+            logger.debug("Initializing db at '%s'", self._PKI_DB_PATH)
             self._check_call("initializing the database", "certutil -N --empty-password -d %s" % self._SQL_PKI_DB_PATH)
 
     def _get_is_registered_cmd(self):

--- a/python/tk_framework_desktopserver/command.py
+++ b/python/tk_framework_desktopserver/command.py
@@ -17,6 +17,8 @@ import sys
 import traceback
 from .logger import get_logger
 
+logger = get_logger(__name__)
+
 
 class ReadThread(Thread):
     """
@@ -141,7 +143,7 @@ class Command(object):
             except IOError:
                 # This fails on OSX 10.7, but it looks like there's no ill side effect
                 # from failing on that platform so we can ignore it.
-                get_logger().exception("Error while flushing file descriptor:")
+                logger.exception("Error while flushing file descriptor:")
             stdout_t.join()
             stderr_t.join()
 
@@ -154,7 +156,7 @@ class Command(object):
             ret = process.returncode
         except StandardError:
             # Do not log the command line, it might contain sensitive information!
-            get_logger().exception("Error running subprocess:")
+            logger.exception("Error running subprocess:")
 
             ret = 1
             stderr_lines = traceback.format_exc().split()
@@ -235,7 +237,7 @@ class Command(object):
             ret = process.returncode
 
         except StandardError:
-            get_logger().exception("Error running subprocess:")
+            logger.exception("Error running subprocess:")
 
             ret = 1
             stderr_lines = [traceback.format_exc().split()]

--- a/python/tk_framework_desktopserver/logger.py
+++ b/python/tk_framework_desktopserver/logger.py
@@ -8,17 +8,13 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import logging
+import sgtk
 
-
-def get_logger(child_logger=None):
+def get_logger(child_logger):
     """
     Returns the logger used by this framework.
     """
-    # Follow 0.18 naming convention so the logging is picked up automatically by the new framework.
-    # Note that Toolkit is not available during startup of the Desktop 1.x so we can't rely on the API
-    # to build a proper logger name.
-    if not child_logger:
-        return logging.getLogger("sgtk.ext.tk-framework-desktopserver")
-    else:
-        return logging.getLogger("sgtk.ext.tk-framework-desktopserver.%s" % child_logger)
+    try:
+        return sgtk.platform.get_logger(child_logger)
+    except:
+        return sgtk.LogManager.get_logger("tk-framework.desktopserver.%s" % child_logger)

--- a/python/tk_framework_desktopserver/message_host.py
+++ b/python/tk_framework_desktopserver/message_host.py
@@ -12,6 +12,8 @@ from .message import Message
 from .logger import get_logger
 from twisted.internet import reactor
 
+logger = get_logger(__name__)
+
 
 class MessageHost(object):
     """
@@ -52,7 +54,7 @@ class MessageHost(object):
         :param error_message: String error message
         :param data: Optional object data to send in reply
         """
-        get_logger().info("Websocket client error: %s" % error_message)
+        logger.info("Websocket client error: %s" % error_message)
         message = Message(self._message["id"], self._host.PROTOCOL_VERSION)
         message.error(error_message, error_data)
 

--- a/python/tk_framework_desktopserver/server.py
+++ b/python/tk_framework_desktopserver/server.py
@@ -33,9 +33,9 @@ class Server(object):
     _DEFAULT_KEYS_PATH = "../resources/keys"
 
     class Notifier(QtCore.QObject):
-        different_user_requested = QtCore.Signal(str, str)
+        different_user_requested = QtCore.Signal(str, int)
 
-    def __init__(self, keys_path, user, port=None, low_level_debug=False):
+    def __init__(self, keys_path, host, user_id, port=None, low_level_debug=False):
         """
         Constructor.
 
@@ -47,7 +47,8 @@ class Server(object):
         self._port = port or self._DEFAULT_PORT
         self._keys_path = keys_path or self._DEFAULT_KEYS_PATH
         self._debug = low_level_debug
-        self._user = user
+        self._host = host
+        self._user_id = user_id
 
         self.notifier = self.Notifier()
 
@@ -110,7 +111,8 @@ class Server(object):
         )
 
         self.factory.protocol = ServerProtocol
-        self.factory.user = self._user
+        self.factory.host = self._host
+        self.factory.user_id = self._user_id
         self.factory.notifier = self.notifier
         self.factory.setProtocolOptions(allowHixie76=True, echoCloseCodeReason=True)
         try:

--- a/python/tk_framework_desktopserver/server.py
+++ b/python/tk_framework_desktopserver/server.py
@@ -31,11 +31,9 @@ logger = get_logger(__name__)
 class Server(object):
     _DEFAULT_PORT = 9000
     _DEFAULT_KEYS_PATH = "../resources/keys"
-    _DEFAULT_WHITELIST = "*.shotgunstudio.com"
 
     class Notifier(QtCore.QObject):
-        different_site_requested = QtCore.Signal(str, str)
-        different_user_requested = QtCore.Signal(str)
+        different_user_requested = QtCore.Signal(str, str)
 
     def __init__(self, keys_path, user, port=None, low_level_debug=False):
         """
@@ -45,16 +43,11 @@ class Server(object):
             current working directory. Mandatory
         :param port: Port to listen for websocket requests from.
         :param low_level_debug: If True, wss traffic will be written to the console.
-        :param whitelist: Comma separated list of sites that can connect to the server.
-            For example:
-                - *.shotgunstudio.com (default)
-                - some-site.shotgunstudio.com
-                - localserver.localnetwork.com
-                - some-site.shotgunstudio.com,some-other-site.shotgunstudio.com
         """
         self._port = port or self._DEFAULT_PORT
         self._keys_path = keys_path or self._DEFAULT_KEYS_PATH
         self._debug = low_level_debug
+        self._user = user
 
         self.notifier = self.Notifier()
 
@@ -119,8 +112,8 @@ class Server(object):
         )
 
         self.factory.protocol = ServerProtocol
-        self.factory.user = user
-        self.factory.notifier = notifier
+        self.factory.user = self._user
+        self.factory.notifier = self.notifier
         self.factory.setProtocolOptions(allowHixie76=True, echoCloseCodeReason=True)
         try:
             self.listener = listenWS(self.factory, self.context_factory)

--- a/python/tk_framework_desktopserver/server.py
+++ b/python/tk_framework_desktopserver/server.py
@@ -37,7 +37,7 @@ class Server(object):
         different_site_requested = QtCore.Signal(str, str)
         different_user_requested = QtCore.Signal(str)
 
-    def __init__(self, keys_path, port=None, low_level_debug=False, whitelist=None):
+    def __init__(self, keys_path, user, port=None, low_level_debug=False):
         """
         Constructor.
 
@@ -54,7 +54,6 @@ class Server(object):
         """
         self._port = port or self._DEFAULT_PORT
         self._keys_path = keys_path or self._DEFAULT_KEYS_PATH
-        self._whitelist = whitelist or self._DEFAULT_WHITELIST
         self._debug = low_level_debug
 
         self.notifier = self.Notifier()
@@ -120,7 +119,8 @@ class Server(object):
         )
 
         self.factory.protocol = ServerProtocol
-        self.factory.websocket_server_whitelist = self._whitelist
+        self.factory.user = user
+        self.factory.notifier = notifier
         self.factory.setProtocolOptions(allowHixie76=True, echoCloseCodeReason=True)
         try:
             self.listener = listenWS(self.factory, self.context_factory)

--- a/python/tk_framework_desktopserver/server_protocol.py
+++ b/python/tk_framework_desktopserver/server_protocol.py
@@ -25,6 +25,8 @@ from autobahn import websocket
 from autobahn.twisted.websocket import WebSocketServerProtocol
 from twisted.internet import error, reactor
 
+logger = get_logger(__name__)
+
 
 class ServerProtocol(WebSocketServerProtocol):
     """
@@ -35,7 +37,6 @@ class ServerProtocol(WebSocketServerProtocol):
     PROTOCOL_VERSION = 1
 
     def __init__(self):
-        self._logger = get_logger()
         self.process_manager = ProcessManager.create()
 
     def onClose(self, wasClean, code, reason):
@@ -56,13 +57,13 @@ class ServerProtocol(WebSocketServerProtocol):
             certificate_error |= bool(reason.check(error.CertificateError))
 
             if certificate_error:
-                self._logger.info("Certificate error!")
+                logger.info("Certificate error!")
                 StatusServerProtocol.serverStatus = StatusServerProtocol.SSL_CERTIFICATE_INVALID
             else:
-                self._logger.info("Connection closed.")
+                logger.info("Connection closed.")
                 StatusServerProtocol.serverStatus = StatusServerProtocol.CONNECTION_LOST
         except Exception:
-            self._logger.exception("Unexpected error while losing connection.")
+            logger.exception("Unexpected error while losing connection.")
             StatusServerProtocol.serverStatus = StatusServerProtocol.CONNECTION_LOST
 
     def onConnect(self, response):
@@ -79,11 +80,11 @@ class ServerProtocol(WebSocketServerProtocol):
         domain_valid = True
 
         if not domain_valid:
-            self._logger.info("Invalid domain: %s" % response.origin)
+            logger.info("Invalid domain: %s" % response.origin)
             # Don't accept connection
             raise websocket.http.HttpException(403, "Domain origin was rejected by server.")
         else:
-            self._logger.info("Connection accepted.")
+            logger.info("Connection accepted.")
 
     def onMessage(self, payload, isBinary):
         """
@@ -173,7 +174,7 @@ class ServerProtocol(WebSocketServerProtocol):
         error["error_message"] = message
 
         # Log error to console
-        self._logger.warning("Error in reply: " + message)
+        logger.warning("Error in reply: " + message)
 
         self.json_reply(error)
 

--- a/python/tk_framework_desktopserver/server_protocol.py
+++ b/python/tk_framework_desktopserver/server_protocol.py
@@ -144,7 +144,7 @@ class ServerProtocol(WebSocketServerProtocol):
 
         if self._protocol_version == 2:
 
-            # Version 2 of the protocol can't only answer requests from the site and user the server
+            # Version 2 of the protocol can only answer requests from the site and user the server
             # is authenticated into. Validate this.
 
             # origin is formatted such as https://xyz.shotgunstudio.com:port_number
@@ -178,14 +178,6 @@ class ServerProtocol(WebSocketServerProtocol):
             message,
             message["protocol_version"],
         )
-
-    def _get_user_id(self, message):
-
-        for key in ["command", "data", "user", "entity", "id"]:
-            if key not in message:
-                return None
-            message = message[key]
-        return message
 
     def _process_message(self, message_host, message, protocol_version):
 

--- a/python/tk_framework_desktopserver/server_protocol.py
+++ b/python/tk_framework_desktopserver/server_protocol.py
@@ -157,15 +157,16 @@ class ServerProtocol(WebSocketServerProtocol):
                 user_id = message["command"]["data"]["user"]["entity"]["id"]
             except Exception:
                 logger.exception("Unexpected error while trying to retrieve the user id.")
-                message_host.report_error("No user information was found in this request.")
+                self.sendClose(3000, u"No user information was found in this request.")
                 return
 
             # If the hosts are different or the user ids are different, report an error.
             if host_network != origin_network or user_id != self.factory.user_id:
                 self.factory.notifier.different_user_requested.emit(self._origin, user_id)
-                message_host.report_error(
-                    "You are not authorized to make browser integration requests. "
-                    "Please re-authenticate in your desktop application."
+                self.sendClose(
+                    3001,
+                    u"You are not authorized to make browser integration requests. "
+                    u"Please re-authenticate in your desktop application."
                 )
                 return
 

--- a/python/tk_framework_desktopserver/server_protocol.py
+++ b/python/tk_framework_desktopserver/server_protocol.py
@@ -68,7 +68,7 @@ class ServerProtocol(WebSocketServerProtocol):
     def onConnect(self, response):
         """
         Called upon client connection to server. This is where we decide if we accept the connection
-        or refuse it based on domain origin filtering.
+        or refuse it based on domain origin.
 
         :param response: Object Response information.
         """
@@ -76,12 +76,7 @@ class ServerProtocol(WebSocketServerProtocol):
         # If we reach this point, then it means SSL handshake went well..
         StatusServerProtocol.serverStatus = StatusServerProtocol.CONNECTED
 
-        domain_valid = False
-        try:
-            # response.origin: xyz.shotgunstudio.com
-            domain_valid = self._is_domain_valid(response.origin)
-        except:
-            self._logger.exception("Unexpected error while trying to determine the originating domain.")
+        domain_valid = True
 
         if not domain_valid:
             self._logger.info("Invalid domain: %s" % response.origin)
@@ -233,29 +228,6 @@ class ServerProtocol(WebSocketServerProtocol):
             return True
         else:
             return False
-
-    def _is_domain_valid(self, origin_str):
-        """
-        Filters for valid origin domain names.
-
-        :param origin_str: Domain origin string (ex: http://localhost:8080)
-        :return: True if domain is accepted, False otherwise
-        """
-        domain_env = os.environ.get("SHOTGUN_PLUGIN_DOMAIN_RESTRICTION", self.factory.websocket_server_whitelist)
-
-        origin = urlparse(origin_str)
-
-        # split domain on commas
-        domain_match = False
-        domains = domain_env.split(",")
-        for domain in domains:
-            domain = domain.strip()
-
-            domain_match = self._wildcard_match(domain, origin.hostname)
-            if domain_match:
-                break
-
-        return domain_match
 
     def _json_date_handler(self, obj):
         """

--- a/python/tk_framework_desktopserver/settings.py
+++ b/python/tk_framework_desktopserver/settings.py
@@ -31,7 +31,6 @@ class Settings(object):
 
     _DEFAULT_PORT = 9000
     _DEFAULT_LOW_LEVEL_DEBUG_VALUE = False
-    _DEFAULT_WHITELIST = "*.shotgunstudio.com"
 
     _BROWSER_INTEGRATION = "BrowserIntegration"
     _PORT_SETTING = "port"

--- a/python/tk_framework_desktopserver/settings.py
+++ b/python/tk_framework_desktopserver/settings.py
@@ -26,18 +26,15 @@ class Settings(object):
     [BrowserIntegration]
     port=9000
     debug=1
-    whitelist=*.shotgunstudio.com
     certificate_folder=/path/to/the/certificate
     """
 
     _DEFAULT_PORT = 9000
     _DEFAULT_LOW_LEVEL_DEBUG_VALUE = False
-    _DEFAULT_WHITELIST = "*.shotgunstudio.com"
 
     _BROWSER_INTEGRATION = "BrowserIntegration"
     _PORT_SETTING = "port"
     _LOW_LEVEL_DEBUG_SETTING = "low_level_debug"
-    _WHITELIST_SETTING = "whitelist"
     _CERTIFICATE_FOLDER_SETTING = "certificate_folder"
     _ENABLED = "enabled"
 
@@ -67,9 +64,6 @@ class Settings(object):
                     config, self._LOW_LEVEL_DEBUG_SETTING, int
                 )
             )
-            whitelist = self._get_value(
-                config, self._WHITELIST_SETTING
-            )
             certificate_folder = self._get_value(
                 config, self._CERTIFICATE_FOLDER_SETTING
             )
@@ -85,9 +79,6 @@ class Settings(object):
             low_level_debug = user_settings.get_boolean_setting(
                 self._BROWSER_INTEGRATION, self._LOW_LEVEL_DEBUG_SETTING
             )
-            whitelist = user_settings.get_setting(
-                self._BROWSER_INTEGRATION, self._WHITELIST_SETTING
-            )
             certificate_folder = user_settings.get_setting(
                 self._BROWSER_INTEGRATION, self._CERTIFICATE_FOLDER_SETTING
             )
@@ -95,7 +86,6 @@ class Settings(object):
 
         self._port = port or self._DEFAULT_PORT
         self._low_level_debug = low_level_debug or self._DEFAULT_LOW_LEVEL_DEBUG_VALUE
-        self._whitelist = whitelist or self._DEFAULT_WHITELIST
         self._certificate_folder = certificate_folder or self._default_certificate_folder
         self._integration_enabled = integration_enabled
 
@@ -136,13 +126,6 @@ class Settings(object):
         return self._low_level_debug
 
     @property
-    def whitelist(self):
-        """
-        :returns: The list of clients that can connect to the server.
-        """
-        return self._whitelist
-
-    @property
     def certificate_folder(self):
         """
         :returns: Path to the certificate location.
@@ -160,7 +143,6 @@ class Settings(object):
         logger.info("Certificate folder: %s" % self.certificate_folder)
         logger.info("Low level debug: %s" % self.low_level_debug)
         logger.info("Port: %d" % self.port)
-        logger.info("Whitelist: %s" % self.whitelist)
 
     def _get_value(self, config, key, type_cast=str):
         """

--- a/python/tk_framework_desktopserver/settings.py
+++ b/python/tk_framework_desktopserver/settings.py
@@ -153,6 +153,10 @@ class Settings(object):
         """
         Dumps all the settings into the logger.
         """
+        if self.integration_enabled is None:
+            logger.info("Integration enabled: <missing>")
+        else:
+            logger.info("Integration enabled: %s" % self.integration_enabled)
         logger.info("Certificate folder: %s" % self.certificate_folder)
         logger.info("Low level debug: %s" % self.low_level_debug)
         logger.info("Port: %d" % self.port)
@@ -192,18 +196,3 @@ class Settings(object):
                 config.get(section, key)
             )
         )
-
-    _BROWSER_INTEGRATION = "BrowserIntegration"
-
-    def dump(self, logger):
-        """
-        Dumps Desktop settings inside the logger.
-
-        :param logger: Logger to write the information to.
-        """
-        logger.info("Custom user setting for Shotgun Desktop:")
-        if self.integration_enabled is None:
-            logger.info("Integration enabled: <missing>")
-        else:
-            logger.info("Integration enabled: %s" % self.integration_enabled)
-

--- a/python/tk_framework_desktopserver/settings.py
+++ b/python/tk_framework_desktopserver/settings.py
@@ -149,14 +149,6 @@ class Settings(object):
         """
         return self._certificate_folder
 
-    @property
-    def integration_enabled(self):
-        """
-        :returns: True if the websocket should run, False otherwise.
-        """
-
-
-
     def dump(self, logger):
         """
         Dumps all the settings into the logger.

--- a/python/tk_framework_desktopserver/settings.py
+++ b/python/tk_framework_desktopserver/settings.py
@@ -73,7 +73,7 @@ class Settings(object):
             certificate_folder = self._get_value(
                 config, self._CERTIFICATE_FOLDER_SETTING
             )
-            is_enabled = self._get_value(
+            integration_enabled = self._get_value(
                 config, self._ENABLED
             )
         else:
@@ -124,7 +124,7 @@ class Settings(object):
         """
         :returns: True if the browser integration is enabled, False otherwise.
         """
-        return self._is_enabled
+        return self._integration_enabled
 
     @property
     def low_level_debug(self):

--- a/python/tk_framework_desktopserver/settings.py
+++ b/python/tk_framework_desktopserver/settings.py
@@ -39,6 +39,7 @@ class Settings(object):
     _LOW_LEVEL_DEBUG_SETTING = "low_level_debug"
     _WHITELIST_SETTING = "whitelist"
     _CERTIFICATE_FOLDER_SETTING = "certificate_folder"
+    _ENABLED = "enabled"
 
     def __init__(self, location, default_certificate_folder):
         """
@@ -72,6 +73,9 @@ class Settings(object):
             certificate_folder = self._get_value(
                 config, self._CERTIFICATE_FOLDER_SETTING
             )
+            is_enabled = self._get_value(
+                config, self._ENABLED
+            )
         else:
             from sgtk.util import UserSettings
             user_settings = UserSettings()
@@ -87,11 +91,13 @@ class Settings(object):
             certificate_folder = user_settings.get_setting(
                 self._BROWSER_INTEGRATION, self._CERTIFICATE_FOLDER_SETTING
             )
+            integration_enabled = UserSettings().get_boolean_setting(self._BROWSER_INTEGRATION, self._ENABLED)
 
         self._port = port or self._DEFAULT_PORT
         self._low_level_debug = low_level_debug or self._DEFAULT_LOW_LEVEL_DEBUG_VALUE
         self._whitelist = whitelist or self._DEFAULT_WHITELIST
         self._certificate_folder = certificate_folder or self._default_certificate_folder
+        self._integration_enabled = integration_enabled
 
     def _load_config(self, path):
         """
@@ -112,6 +118,13 @@ class Settings(object):
         :returns: The port to listen on for incoming websocket requests.
         """
         return self._port
+
+    @property
+    def integration_enabled(self):
+        """
+        :returns: True if the browser integration is enabled, False otherwise.
+        """
+        return self._is_enabled
 
     @property
     def low_level_debug(self):
@@ -135,6 +148,14 @@ class Settings(object):
         :returns: Path to the certificate location.
         """
         return self._certificate_folder
+
+    @property
+    def integration_enabled(self):
+        """
+        :returns: True if the websocket should run, False otherwise.
+        """
+
+
 
     def dump(self, logger):
         """
@@ -179,3 +200,18 @@ class Settings(object):
                 config.get(section, key)
             )
         )
+
+    _BROWSER_INTEGRATION = "BrowserIntegration"
+
+    def dump(self, logger):
+        """
+        Dumps Desktop settings inside the logger.
+
+        :param logger: Logger to write the information to.
+        """
+        logger.info("Custom user setting for Shotgun Desktop:")
+        if self.integration_enabled is None:
+            logger.info("Integration enabled: <missing>")
+        else:
+            logger.info("Integration enabled: %s" % self.integration_enabled)
+


### PR DESCRIPTION
Adds a new signal that is emitted when a websocket request is made not for the current user or site. Closes immediately the connection.

This effectively renders whitelisting redundant and as such was removed. Note that we now always accept connections but disconnect as soon as we know which user made a request.