### PR TITLE
For #42750, #42771, #42772: QA fixes.

### DIFF
--- a/hooks/browser_integration.py
+++ b/hooks/browser_integration.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Hook that provides utilities used by Toolkit's browser integration.
+"""
+
+import sgtk
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+class BrowserIntegration(HookBaseClass):
+    def get_cache_key(self, config_uri, project, entity_type):
+        """
+        Computes the key used to uniquely identify a row in the cache database for
+        the given pipeline configuration uri and entity type. This method can be used
+        to change how a specific entity type is cached, should that be desired.
+
+        .. Note:
+            Changing the logic in this method will invalidate related cache entries
+            that already exist in the cache.
+
+        :param str config_uri: A descriptor uri for the pipeline configuration.
+        :param dict project: The project entity.
+        :param str entity_type: The entity type.
+
+        :returns: A uniquely-identifiable key.
+        :rtype: str
+        """
+        return "%s@%s" % (config_uri, entity_type)
+
+    def get_site_state_data(self):
+        """
+        Builds a list of dictionaries matching the kwargs expected by the
+        Shotgun Python API's find method. These will be queried at the time
+        when a contents state hash is generated during cache population or
+        lookup. This hash is then used to verify that the data found in the
+        cache is still valid. Customization of this method's logic can be
+        used to control what determines whether cached data is valid or not.
+        By default, we track the state of the Shotgun site's Software entities
+        to determine whether any fields there have changed since the data was
+        cached.
+
+        .. Note:
+            Changing the logic in this method will invalidate related cache
+            entries that already exist in the cache.
+
+        :returns: A list of dictionaries containing kwargs that will be passed
+            to the Shotgun Python API's find method.
+        :rtype: list
+        """
+        data_requests = []
+        data_requests.append(
+            dict(
+                entity_type="Software",
+                filters=[],
+                fields=self.parent.shotgun.schema_field_read("Software").keys(),
+            )
+        )
+
+        return data_requests
+
+    def process_commands(self, commands, project, entities):
+        """
+        Allows for pre-processing of the commands that will be returned to the client.
+        Overriding the logic in this method could be used, for example, to filter out
+        certain commands from being passed up to the client.
+
+        :param list commands: A list of dictionaries, each containing information
+            about a command to be passed up to the client. Each dict will include
+            the following keys: name, title, app_name, deny_permissions, and
+            supports_multiple_selection.
+        :param dict project: The project entity.
+        :param list entities: A list of entity dictionaries representing all entities
+            that were selected in the web client.
+
+        .. Example:
+            dict(
+                name="launch_maya",
+                title="Maya 2017",
+                deny_permissions=[],
+                supports_multiple_selection=False,
+                app_name="tk-multi-launchapp",
+                group="Maya",
+                group_default=True,
+                engine_name="tk-maya",
+            )
+
+        :returns: Processed commands.
+        :rtype: list
+        """
+        return commands
+
+
+

--- a/info.yml
+++ b/info.yml
@@ -12,6 +12,10 @@
 
 # expected fields in the configuration file for this engine
 configuration:
+    browser_integration_hook:
+        type: hook
+        description: Hook for customizing some aspects of Toolkit's integration with the Shotgun web app.
+        default_value: '{self}/browser_integration.py'
 
 # the Shotgun fields that this engine needs in order to operate correctly
 requires_shotgun_fields:
@@ -22,7 +26,7 @@ description: "Provides the server used to listen to Shotgun client requests, suc
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.14.41"
+requires_core_version: "v0.16.0"
 
  
         

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -787,8 +787,8 @@ class ShotgunAPI(object):
             entity_type = self._get_task_parent_entity_type(entity_id)
             logger.debug("Task entity's parent entity type: %s", entity_type)
 
-        return self._engine.sgtk.execute_core_hook_method(
-            "browser_integration",
+        return self._bundle.execute_hook_method(
+            "browser_integration_hook",
             "get_cache_key",
             config_uri=config_uri,
             project=project,
@@ -934,7 +934,7 @@ class ShotgunAPI(object):
     def _get_site_state_data(self):
         """
         Gets state-related data for the site. Exactly what data this is depends
-        on the "browser_integration" core hook's "get_site_state_data" method,
+        on the "browser_integration" hook's "get_site_state_data" method,
         which returns a list of dicts passed to the Shotgun Python API's find
         method as kwargs. The data returned by this method is cached based on
         the WSS connection key provided to the API's constructor at instantiation
@@ -947,8 +947,8 @@ class ShotgunAPI(object):
         if self.SITE_STATE_DATA not in self._cache:
             self._cache[self.SITE_STATE_DATA] = []
 
-            requested_data_specs = self._engine.sgtk.execute_core_hook_method(
-                "browser_integration",
+            requested_data_specs = self._bundle.execute_hook_method(
+                "browser_integration_hook",
                 "get_site_state_data",
             )
 
@@ -1020,7 +1020,7 @@ class ShotgunAPI(object):
         """
         Filters out commands that are not associated with an app, and then
         calls the process_commands methods from the browser_integration
-        core hook, returning the result.
+        hook, returning the result.
 
         :param list commands: The list of command dictionaries to be processed.
         :param dict project: The project entity.
@@ -1043,8 +1043,8 @@ class ShotgunAPI(object):
                     "Command %s filtered out for browser integration.", command
                 )
 
-        return self._engine.sgtk.execute_core_hook_method(
-            "browser_integration",
+        return self._bundle.execute_hook_method(
+            "browser_integration_hook",
             "process_commands",
             commands=filtered,
             project=project,

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -150,6 +150,7 @@ class ShotgunAPI(object):
                 sys_path=self._compute_sys_path(),
                 base_configuration=constants.BASE_CONFIG_URI,
                 engine_name=constants.ENGINE_NAME,
+                logging_prefix=constants.LOGGING_PREFIX,
             ),
         )
 
@@ -201,7 +202,7 @@ class ShotgunAPI(object):
         # handler that the execute_command script builds, and we
         # remove that header from those lines and keep them so that
         # they're passed up to the client.
-        tag = "SGTK:"
+        tag = constants.LOGGING_PREFIX
         tag_length = len(tag)
 
         # We check both stdout and stderr. We identify lines that start with
@@ -216,9 +217,8 @@ class ShotgunAPI(object):
                 filtered_output.append(base64.b64decode(line[tag_length:]))
 
         filtered_output_string = "\n".join(filtered_output)
-        logger.debug("Filtered and decoded log output: %s", filtered_output_string)
-
         logger.debug("Command execution complete.")
+
         self.host.reply(
             dict(
                 retcode=constants.COMMAND_SUCCEEDED,

--- a/python/tk_framework_desktopserver/shotgun/constants.py
+++ b/python/tk_framework_desktopserver/shotgun/constants.py
@@ -47,3 +47,9 @@ BASE_ENTITY_TYPE_WHITELIST = set([
     "Task",
     "Version",
 ])
+
+# The execute_command.py script creates a custom log handler that
+# logs messages to stdout. Each message is prefixed with a known
+# tag that we can then use after the command completes to identify
+# output that we want to send back to the client.
+LOGGING_PREFIX = "SGTK:"

--- a/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
@@ -85,7 +85,7 @@ def cache(cache_file, data, base_configuration, engine_name, config_data, config
         it is, then we include the __core_info and __upgrade_check commands.
     """
     engine = bootstrap(data, base_configuration, engine_name, config_data)
-    engine.log_debug("Raw payload from client: %s", data)
+    engine.log_debug("Raw payload from client: %s" % data)
 
     lookup_hash = config_data["lookup_hash"]
     contents_hash = config_data["contents_hash"]
@@ -97,7 +97,7 @@ def cache(cache_file, data, base_configuration, engine_name, config_data, config
     # engine commands. We only do this for mutable configs, as it doesn't
     # make sense to ask for upgrade information for a config that can't be
     # upgraded.
-    engine.log_debug("Configuration data: %s", config_data)
+    engine.log_debug("Configuration data: %s" % config_data)
 
     if data["entity_type"].lower() == "project" and config_is_mutable:
         engine.log_debug("Registering core and app upgrade commands...")
@@ -128,7 +128,7 @@ def cache(cache_file, data, base_configuration, engine_name, config_data, config
             engine.log_debug("Config is immutable: not registering core and app update commands.")
 
     for cmd_name, data in engine.commands.iteritems():
-        engine.log_debug("Processing command: %s", cmd_name)
+        engine.log_debug("Processing command: %s" % cmd_name)
         props = data["properties"]
         app = props.get("app")
 

--- a/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
@@ -128,7 +128,10 @@ def cache(cache_file, data, base_configuration, engine_name, config_data, config
         ])
     else:
         if config_is_mutable:
-            engine.log_debug("Not a Project entity: not registering core and app update commands.")
+            engine.log_debug(
+                "The config is mutable, but this is not a Project entity: "
+                "not registering core and app update commands."
+            )
         else:
             engine.log_debug("Config is immutable: not registering core and app update commands.")
 

--- a/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
@@ -85,6 +85,11 @@ def cache(cache_file, data, base_configuration, engine_name, config_data, config
         it is, then we include the __core_info and __upgrade_check commands.
     """
     engine = bootstrap(data, base_configuration, engine_name, config_data)
+
+    # Note that from here on out, we have to use the legacy log_* methods
+    # that the engine provides. This is because we're now operating in the
+    # tk-core that is configured for the project, which means we can't
+    # guarantee that it is v0.18+.
     engine.log_debug("Raw payload from client: %s" % data)
 
     lookup_hash = config_data["lookup_hash"]

--- a/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
@@ -62,7 +62,7 @@ def core_info(engine):
     # Create an upgrader instance that we can query if the install is up to date.
     installer = TankCoreUpdater(
         engine.sgtk.pipeline_configuration.get_install_location(),
-        logger,
+        engine._log,
     )
 
     cv = installer.get_current_version_number()

--- a/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
@@ -29,14 +29,11 @@ def app_upgrade_info(engine):
 
     :param engine: The currently-running engine instance.
     """
-    code_css_block = "display: block; padding: 0.5em 1em; border: 1px solid #bebab0; background: #faf8f0;"
-
     engine.log_info(
         "In order to check if your installed apps and engines are up to date, "
         "you can run the following command in a console:"
     )
 
-    engine.log_info("")
     config_root = engine.sgtk.pipeline_configuration.get_path()
 
     if sys.platform == "win32":
@@ -44,7 +41,7 @@ def app_upgrade_info(engine):
     else:
         tank_cmd = os.path.join(config_root, "tank")
 
-    engine.log_info("<code style='%s'>%s updates</code>" % (code_css_block, tank_cmd))
+    engine.log_info("*%s updates*" % tank_cmd)
     engine.log_info("")
 
 def core_info(engine):
@@ -56,8 +53,6 @@ def core_info(engine):
     """
     import sgtk
     from sgtk.commands.core_upgrade import TankCoreUpdater
-
-    code_css_block = "display: block; padding: 0.5em 1em; border: 1px solid #bebab0; background: #faf8f0;"
 
     # Create an upgrader instance that we can query if the install is up to date.
     installer = TankCoreUpdater(
@@ -75,7 +70,7 @@ def core_info(engine):
     if not engine.sgtk.pipeline_configuration.is_localized():
         engine.log_info("")
         engine.log_info(
-            "Your core API is located in <code>%s</code> and is shared with other "
+            "Your core API is located in `%s` and is shared with other "
             "projects." % install_root
         )
 
@@ -84,23 +79,22 @@ def core_info(engine):
 
     if status == TankCoreUpdater.UP_TO_DATE:
         engine.log_info(
-            "<b>You are up to date! There is no need to update the Toolkit "
-            "Core API at this time!</b>"
+            "*You are up to date! There is no need to update the Toolkit "
+            "Core API at this time!*"
         )
     elif status == TankCoreUpdater.UPDATE_BLOCKED_BY_SG:
         req_sg = installer.get_required_sg_version_for_update()
         engine.log_warning(
-            "<b>A new version (%s) of the core API is available however "
-            "it requires a more recent version (%s) of Shotgun!</b>" % (lv, req_sg)
+            "*A new version (%s) of the core API is available however "
+            "it requires a more recent version (%s) of Shotgun!*" % (lv, req_sg)
         )
     elif status == TankCoreUpdater.UPDATE_POSSIBLE:
         (summary, url) = installer.get_release_notes()
 
-        engine.log_info("<b>A new version of the Toolkit API (%s) is available!</b>" % lv)
+        engine.log_info("*A new version of the Toolkit API (%s) is available!*" % lv)
         engine.log_info("")
         engine.log_info(
-            "<b>Change Summary:</b> %s <a href='%s' target=_new>"
-            "Click for detailed Release Notes</a>" % (summary, url)
+            "*Change Summary:* %s [Click for detailed Release Notes](%s)" % (summary, url)
         )
         engine.log_info("")
         engine.log_info("In order to upgrade, execute the following command in a shell:")
@@ -111,7 +105,7 @@ def core_info(engine):
         else:
             tank_cmd = os.path.join(install_root, "tank")
 
-        engine.log_info("<code style='%s'>%s core</code>" % (code_css_block, tank_cmd))
+        engine.log_info("*%s core*" % tank_cmd)
         engine.log_info("")
     else:
         raise sgtk.TankError("Unknown Upgrade state!")

--- a/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
@@ -18,6 +18,7 @@ import functools
 # Special, non-engine commands that we'll need to handle ourselves.
 CORE_INFO_COMMAND = "__core_info"
 UPGRADE_CHECK_COMMAND = "__upgrade_check"
+LOGGING_PREFIX = None
 
 class _Formatter(logging.Formatter):
     """
@@ -32,10 +33,7 @@ class _Formatter(logging.Formatter):
         making output from a logger using this formatter easily identifiable.
         """
         result = super(_Formatter, self).format(*args, **kwargs)
-        return "{tag}:{log_data}".format(
-            tag="SGTK",
-            log_data=base64.b64encode(result),
-        )
+        return "%s%s" % (LOGGING_PREFIX, base64.b64encode(result))
 
 def app_upgrade_info(engine):
     """
@@ -302,6 +300,9 @@ if __name__ == "__main__":
         arg_data = cPickle.load(fh)
 
     sys.path = arg_data["sys_path"]
+
+    global LOGGING_PREFIX
+    LOGGING_PREFIX = arg_data["logging_prefix"]
 
     execute(
         arg_data["config"],

--- a/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
@@ -29,17 +29,14 @@ def app_upgrade_info(engine):
 
     :param engine: The currently-running engine instance.
     """
-    import sgtk
-    logger = sgtk.LogManager.get_logger(LOGGER_NAME)
-
     code_css_block = "display: block; padding: 0.5em 1em; border: 1px solid #bebab0; background: #faf8f0;"
 
-    logger.info(
+    engine.log_info(
         "In order to check if your installed apps and engines are up to date, "
         "you can run the following command in a console:"
     )
 
-    logger.info("")
+    engine.log_info("")
     config_root = engine.sgtk.pipeline_configuration.get_path()
 
     if sys.platform == "win32":
@@ -47,8 +44,8 @@ def app_upgrade_info(engine):
     else:
         tank_cmd = os.path.join(config_root, "tank")
 
-    logger.info("<code style='%s'>%s updates</code>" % (code_css_block, tank_cmd))
-    logger.info("")
+    engine.log_info("<code style='%s'>%s updates</code>" % (code_css_block, tank_cmd))
+    engine.log_info("")
 
 def core_info(engine):
     """
@@ -59,7 +56,6 @@ def core_info(engine):
     """
     import sgtk
     from sgtk.commands.core_upgrade import TankCoreUpdater
-    logger = sgtk.LogManager.get_logger(LOGGER_NAME)
 
     code_css_block = "display: block; padding: 0.5em 1em; border: 1px solid #bebab0; background: #faf8f0;"
 
@@ -72,51 +68,51 @@ def core_info(engine):
     cv = installer.get_current_version_number()
     lv = installer.get_update_version_number()
 
-    logger.info(
+    engine.log_info(
         "You are currently running version %s of the Shotgun Pipeline Toolkit." % cv
     )
 
     if not engine.sgtk.pipeline_configuration.is_localized():
-        logger.info("")
-        logger.info(
+        engine.log_info("")
+        engine.log_info(
             "Your core API is located in <code>%s</code> and is shared with other "
             "projects." % install_root
         )
 
-    logger.info("")
+    engine.log_info("")
     status = installer.get_update_status()
 
     if status == TankCoreUpdater.UP_TO_DATE:
-        logger.info(
+        engine.log_info(
             "<b>You are up to date! There is no need to update the Toolkit "
             "Core API at this time!</b>"
         )
     elif status == TankCoreUpdater.UPDATE_BLOCKED_BY_SG:
         req_sg = installer.get_required_sg_version_for_update()
-        logger.warning(
+        engine.log_warning(
             "<b>A new version (%s) of the core API is available however "
             "it requires a more recent version (%s) of Shotgun!</b>" % (lv, req_sg)
         )
     elif status == TankCoreUpdater.UPDATE_POSSIBLE:
         (summary, url) = installer.get_release_notes()
 
-        logger.info("<b>A new version of the Toolkit API (%s) is available!</b>" % lv)
-        logger.info("")
-        logger.info(
+        engine.log_info("<b>A new version of the Toolkit API (%s) is available!</b>" % lv)
+        engine.log_info("")
+        engine.log_info(
             "<b>Change Summary:</b> %s <a href='%s' target=_new>"
             "Click for detailed Release Notes</a>" % (summary, url)
         )
-        logger.info("")
-        logger.info("In order to upgrade, execute the following command in a shell:")
-        logger.info("")
+        engine.log_info("")
+        engine.log_info("In order to upgrade, execute the following command in a shell:")
+        engine.log_info("")
 
         if sys.platform == "win32":
             tank_cmd = os.path.join(install_root, "tank.bat")
         else:
             tank_cmd = os.path.join(install_root, "tank")
 
-        logger.info("<code style='%s'>%s core</code>" % (code_css_block, tank_cmd))
-        logger.info("")
+        engine.log_info("<code style='%s'>%s core</code>" % (code_css_block, tank_cmd))
+        engine.log_info("")
     else:
         raise sgtk.TankError("Unknown Upgrade state!")
 
@@ -188,7 +184,6 @@ def execute(config, project, name, entities, base_configuration, engine_name):
     engine = bootstrap(config, base_configuration, entity, engine_name)
 
     import sgtk
-    logger = sgtk.LogManager.get_logger(LOGGER_NAME)
 
     # Handle the "special" commands that aren't tied to any registered engine
     # commands.
@@ -222,7 +217,7 @@ def execute(config, project, name, entities, base_configuration, engine_name):
 
     if not command:
         msg = "Unable to find engine command: %s" % name
-        logger.error(msg)
+        engine.log_error(msg)
         raise sgtk.TankError(msg)
 
     # We need to know whether this command is allowed to be run when multiple


### PR DESCRIPTION
* Fixes a bug that caused failed command executions to not report any output back to the client.
* Implements a custom log handler in `execute_command.py` that outputs to stdout and tags all log messages in such a way that...
* ...stdout can be filtered, cleaned up, and reported back to the client when a command successfully completes.
* Takes ownership of the `browser_integration.py` hook.
* Removes HTML output from core and app upgrade commands, replacing it with simple markdown.