### PR TITLE
For #41692: Changes to support 0.16.x cores with wss2.

### DIFF
--- a/python/tk_framework_desktopserver/server_protocol.py
+++ b/python/tk_framework_desktopserver/server_protocol.py
@@ -262,11 +262,9 @@ class ServerProtocol(WebSocketServerProtocol):
         :param data: Object Data that will be converted to JSON and sent to client.
         """
         # ensure_ascii allows unicode strings.
-        # encoding="utf8" ensures that str objects are encoded utf8 during dump.
         payload = json.dumps(
             data,
             ensure_ascii=False,
-            encoding="utf8",
             default=self._json_date_handler,
         ).encode("utf8")
 

--- a/python/tk_framework_desktopserver/server_protocol.py
+++ b/python/tk_framework_desktopserver/server_protocol.py
@@ -262,7 +262,13 @@ class ServerProtocol(WebSocketServerProtocol):
         :param data: Object Data that will be converted to JSON and sent to client.
         """
         # ensure_ascii allows unicode strings.
-        payload = json.dumps(data, ensure_ascii=False, default=self._json_date_handler).encode("utf8")
+        # encoding="utf8" ensures that str objects are encoded utf8 during dump.
+        payload = json.dumps(
+            data,
+            ensure_ascii=False,
+            encoding="utf8",
+            default=self._json_date_handler,
+        ).encode("utf8")
 
         is_binary = False
         self.sendMessage(payload, is_binary)

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -889,6 +889,14 @@ class ShotgunAPI(object):
             for pipeline_config in pipeline_configs:
                 logger.debug("Processing config: %s", pipeline_config)
 
+                # We're not going to need the project field in the config
+                # entity, since we already know what Project we're dealing
+                # with. In the event that the project name has non-ascii
+                # characters in it, it could also cause unicode decode issues
+                # later on. Best to just ditch it now.
+                if "project" in pipeline_config:
+                    del pipeline_config["project"]
+
                 # The hash that acts as the key we'll use to look up our cached
                 # data will be based on the entity type and the pipeline config's
                 # descriptor uri. We can get the descriptor from the toolkit

--- a/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
@@ -80,6 +80,8 @@ def core_info(engine):
             # EVEN MORE LEGACY. In 0.16.x cores, the class is named differently.
             from sgtk.deploy.tank_commands.core_upgrade import TankCoreUpgrader
             TankCoreUpdater = TankCoreUpgrader
+            TankCoreUpdater.UPDATE_BLOCKED_BY_SG = TankCoreUpdater.UPGRADE_BLOCKED_BY_SG
+            TankCoreUpdater.UPDATE_POSSIBLE = TankCoreUpdater.UPGRADE_POSSIBLE
             legacy_updater = True
 
     # Create an upgrader instance that we can query if the install is up to date.

--- a/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
@@ -73,7 +73,12 @@ def core_info(engine):
         from sgtk.commands.core_upgrade import TankCoreUpdater
     except ImportError:
         engine.log_debug("Legacy core detected, importing from sgtk.deploy.tank_commands.")
-        from sgtk.deploy.tank_commands.core_upgrade import TankCoreUpdater
+        try:
+            from sgtk.deploy.tank_commands.core_upgrade import TankCoreUpdater
+        except ImportError:
+            # EVEN MORE LEGACY. In 0.16.x cores, the class is named differently.
+            from sgtk.deploy.tank_commands.core_upgrade import TankCoreUpgrader
+            TankCoreUpdater = TankCoreUpgrader
 
     # Create an upgrader instance that we can query if the install is up to date.
     install_root = engine.sgtk.pipeline_configuration.get_install_location()
@@ -293,7 +298,7 @@ def execute(config, project, name, entities, base_configuration, engine_name):
         # If the constant doesn't exist, it's because we're in a 0.16.x core.
         # In that case, we just hardcode it to what we know the value to have
         # been at that time. It's the best we can do.
-        ms_flag = "shotgun_multi_select_action"
+        ms_flag = "supports_multiple_selection"
 
     props = command["properties"]
     old_style = ms_flag in props

--- a/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
@@ -68,6 +68,7 @@ def core_info(engine):
     :param engine: The currently-running engine instance.
     """
     import sgtk
+    legacy_updater = False
 
     try:
         from sgtk.commands.core_upgrade import TankCoreUpdater
@@ -79,6 +80,7 @@ def core_info(engine):
             # EVEN MORE LEGACY. In 0.16.x cores, the class is named differently.
             from sgtk.deploy.tank_commands.core_upgrade import TankCoreUpgrader
             TankCoreUpdater = TankCoreUpgrader
+            legacy_updater = True
 
     # Create an upgrader instance that we can query if the install is up to date.
     install_root = engine.sgtk.pipeline_configuration.get_install_location()
@@ -95,7 +97,14 @@ def core_info(engine):
     )
 
     cv = installer.get_current_version_number()
-    lv = installer.get_update_version_number()
+
+    # The interface for the core updater changed with the release of tk-core
+    # 0.17.x. If we know we're dealing with a core that's 0.16.x, we need to
+    # call a different method to get the same information.
+    if legacy_updater:
+        lv = installer.get_latest_version_number()
+    else:
+        lv = installer.get_update_version_number()
 
     # NOTE: The output here is in Slack-style markdown syntax. This means that
     # we can do things like *Show this stuff in bold!* and when it makes it to


### PR DESCRIPTION
These considerations for older cores only need to occur in the portions of the `execute_command` and `cache_actions` subprocesses being run after core swap. That means portions of the logic that occur after bootstrap has completed, including logging via the Shotgun engine, and things like the "special" core upgrade menu action.

One additional fix is that the project entity associated with a PipelineConfiguration is removed from the config's entity dict. It's not needed in the wss2 API, and if it contains a project name that's unicode, we risk UnicodeDecodeErrors when that data is passed back to the client as json.