### PR TITLE
For #43016, fixes a crash on Shotgun Desktop 1.0.2.

### DIFF
--- a/framework.py
+++ b/framework.py
@@ -58,6 +58,13 @@ class DesktopserverFramework(sgtk.platform.Framework):
         :param str host: Host for which we desire to answer requests.
         :param int user_id: Id of the user for which we desire to answer requests.
         """
+        # Twisted only runs on 64-bits.
+        # No not even attempt to import the framework, as it will cause 64-bits DLLs to be loaded.
+        if not self.__is_64bit_python():
+            self.logger.warning("The browser integration is only available with 64-bit versions of Python.")
+            self._integration_enabled = False
+            return
+
         self._tk_framework_desktopserver = self.import_module("tk_framework_desktopserver")
 
         # Read the browser integration settings from disk. By passing in location=None, the Toolkit API will be
@@ -75,12 +82,8 @@ class DesktopserverFramework(sgtk.platform.Framework):
         )
         self._settings.dump(self.logger)
 
-        # Twisted only runs on 64-bits.
-        if not self.__is_64bit_python():
-            self.logger.warning("The browser integration is only available with 64-bit versions of Python.")
-            self._integration_enabled = False
         # Did the user disable it?
-        elif not self._settings.integration_enabled:
+        if not self._settings.integration_enabled:
             self.logger.info("Browser integration has been disabled in the Toolkit settings.")
             self._integration_enabled = False
         else:


### PR DESCRIPTION
The code attemps to load the twisted module, which will raise an error with a 32-bit Desktop since some DLLs are involved. Oddly, launching Desktop from the console always worked, but launching it from the Start menu crashed roughly 3 times out of 4. Now it always works.