### PR TITLE
For #43057: Implements a legacy code path for classic sgtk projects.

### DIFF
--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -25,7 +25,6 @@ import base64
 
 import sgtk
 from sgtk.commands.clone_configuration import clone_pipeline_configuration_html
-from sgtk.util.shotgun_path import ShotgunPath
 from . import constants
 from .. import command
 

--- a/python/tk_framework_desktopserver/shotgun/constants.py
+++ b/python/tk_framework_desktopserver/shotgun/constants.py
@@ -53,3 +53,10 @@ BASE_ENTITY_TYPE_WHITELIST = set([
 # tag that we can then use after the command completes to identify
 # output that we want to send back to the client.
 LOGGING_PREFIX = "SGTK:"
+
+# This is part of a workaround that causes "classic" SGTK configs to
+# be processed by way of the "tank" command rather than going through
+# the more modern code path that utilizes the bootstrap API.
+LEGACY_CONFIG_ROOT = "_legacy_config_root"
+LEGACY_EXEMPT_ACTIONS = ["__core_info", "__upgrade_check"]
+DISABLE_LEGACY_BROWSER_INTEGRATION_WORKAROUND = "SGTK_DISABLE_LEGACY_BROWSER_INTEGRATION_WORKAROUND"


### PR DESCRIPTION
If a project contains classic-style PipelineConfiguration entities, then its get_actions and engine command execution routines call through a legacy code path. This legacy path makes use of the tank command, as the v1 wss API did.