### PR TITLE
For #43159, chrome 59 fix

### DIFF
--- a/app/certificates.py
+++ b/app/certificates.py
@@ -71,7 +71,7 @@ def __remove_certificate(certificate_folder, logger):
     # Removes the actual certificate files on disk.
     if cert_handler.exists():
         logger.debug("Certificate was found on disk at %s." % certificate_folder)
-        cert_handler.remove_files()
+        cert_handler.backup_files()
         logger.info("The certificate was removed at %s." % certificate_folder)
     else:
         logger.info("No certificate was found on disk at %s." % certificate_folder)

--- a/framework.py
+++ b/framework.py
@@ -57,6 +57,8 @@ class DesktopserverFramework(sgtk.platform.Framework):
 
         :param str host: Host for which we desire to answer requests.
         :param int user_id: Id of the user for which we desire to answer requests.
+        :param parent: Parent widget for any pop-ups to show during initialization.
+        :type parent: :class:`PySide.QtGui.QWidget`
         """
         self._tk_framework_desktopserver = self.import_module("tk_framework_desktopserver")
 
@@ -105,6 +107,12 @@ class DesktopserverFramework(sgtk.platform.Framework):
             self.logger.exception("Could not start the browser integration:")
 
     def regenerate_certificates(self, parent=None):
+        """
+        Regenerates the certificates.
+
+        :param parent: Parent widget for any pop-ups to show during certificate generation.
+        :type parent: :class:`PySide.QtGui.QWidget`
+        """
         self.__ensure_certificate_ready(regenerate_certs=True, parent=parent)
 
     def destroy_framework(self):
@@ -120,6 +128,10 @@ class DesktopserverFramework(sgtk.platform.Framework):
         """
         Ensures that the certificates are created and registered. If something is amiss, then the
         certificates are regenerated.
+
+        :param bool regenerate_certs: If ``True``, certificates will be regenerated.
+        :param parent: Parent widget for any pop-ups to show during certificate generation.
+        :type parent: :class:`PySide.QtGui.QWidget`
         """
         cert_handler = self._tk_framework_desktopserver.get_certificate_handler(
             self._settings.certificate_folder

--- a/framework.py
+++ b/framework.py
@@ -47,7 +47,7 @@ class DesktopserverFramework(sgtk.platform.Framework):
 
     ##########################################################################################
     # init and destroy
-    def launch_desktop_server(self, host, user_id):
+    def launch_desktop_server(self, host, user_id, parent=None):
         """
         Initializes the desktop server.
 
@@ -90,7 +90,7 @@ class DesktopserverFramework(sgtk.platform.Framework):
             return
 
         try:
-            self.__ensure_certificate_ready()
+            self.__ensure_certificate_ready(regenerate_certs=False, parent=parent)
 
             self._server = self._tk_framework_desktopserver.Server(
                 keys_path=self._settings.certificate_folder,
@@ -104,6 +104,9 @@ class DesktopserverFramework(sgtk.platform.Framework):
         except Exception:
             self.logger.exception("Could not start the browser integration:")
 
+    def regenerate_certificates(self, parent=None):
+        self.__ensure_certificate_ready(regenerate_certs=True, parent=parent)
+
     def destroy_framework(self):
         """
         Called on finalization of the framework.
@@ -113,7 +116,7 @@ class DesktopserverFramework(sgtk.platform.Framework):
         if self._server and self._server.is_running():
             self._server.tear_down()
 
-    def __ensure_certificate_ready(self):
+    def __ensure_certificate_ready(self, regenerate_certs=False, parent=None):
         """
         Ensures that the certificates are created and registered. If something is amiss, then the
         certificates are regenerated.
@@ -121,6 +124,10 @@ class DesktopserverFramework(sgtk.platform.Framework):
         cert_handler = self._tk_framework_desktopserver.get_certificate_handler(
             self._settings.certificate_folder
         )
+
+        if regenerate_certs:
+            self.logger.info("Backing up current certificates files if they exist.")
+            cert_handler.backup_files()
 
         # We only warn once.
         warned = False
@@ -132,7 +139,7 @@ class DesktopserverFramework(sgtk.platform.Framework):
             if cert_handler.is_registered():
                 self.logger.info("Unregistering lingering certificate.")
                 # Warn once.
-                self.__warn_for_prompt()
+                self.__warn_for_prompt(parent)
                 warned = True
                 cert_handler.unregister()
                 self.logger.info("Unregistered.")
@@ -148,7 +155,7 @@ class DesktopserverFramework(sgtk.platform.Framework):
 
             # Only if we've never been warned before.
             if not warned:
-                self.__warn_for_prompt()
+                self.__warn_for_prompt(parent)
             cert_handler.register()
             self.logger.info("Certificate registered.")
         else:
@@ -165,9 +172,10 @@ class DesktopserverFramework(sgtk.platform.Framework):
         """
         return ("The Shotgun Desktop needs to update the security certificate list from your %s before "
                 "it can turn on the browser integration.\n"
+                "\n"
                 "%s" % (keychain_name, action))
 
-    def __warn_for_prompt(self):
+    def __warn_for_prompt(self, parent):
         """
         Warn the user he will be prompted.
         """
@@ -175,7 +183,7 @@ class DesktopserverFramework(sgtk.platform.Framework):
 
         if sys.platform == "darwin":
             QtGui.QMessageBox.information(
-                None,
+                parent,
                 "Shotgun browser integration",
                 self.__get_certificate_prompt(
                     "keychain",
@@ -185,7 +193,7 @@ class DesktopserverFramework(sgtk.platform.Framework):
             )
         elif sys.platform == "win32":
             QtGui.QMessageBox.information(
-                None,
+                parent,
                 "Shotgun browser integration",
                 self.__get_certificate_prompt(
                     "Windows certificate store",

--- a/python/tk_framework_desktopserver/certificates.py
+++ b/python/tk_framework_desktopserver/certificates.py
@@ -50,7 +50,7 @@ class _CertificateHandler(object):
 
     def backup_files(self):
         """
-        Removes the files from the
+        Backups the certificate files to the backup/year-month-day-hour-minute-second folder.
         """
         parent_folder = os.path.dirname(self._cert_path)
         backup_folder = os.path.join(
@@ -63,7 +63,7 @@ class _CertificateHandler(object):
 
     def _backup_file(self, src_file, dst_folder):
         """
-        Takes a certificate file (if it exists) and moves it to the backup folder.
+        Takes a certificate file (if it exists) and moves it to the destination folder.
 
         :param src_file: File to move.
         :param dst_folder: Folder in which we will be backing up the file.

--- a/python/tk_framework_desktopserver/certificates.py
+++ b/python/tk_framework_desktopserver/certificates.py
@@ -83,7 +83,7 @@ class _CertificateHandler(object):
         logger.debug("Backing up certificate from '%s' to '%s'.", src_file, dst_file)
 
         # If the backup folder does not exist, create it.
-        sgtk.util.ensure_folder_exists(dst_folder)
+        sgtk.util.filesystem.ensure_folder_exists(dst_folder)
 
         os.rename(src_file, dst_file)
 
@@ -237,7 +237,7 @@ class _CertificateHandler(object):
         """
         folder = os.path.dirname(filepath)
         logger.info("Ensuring '%s' exists.", folder)
-        sgtk.util.ensure_folder_exists(folder)
+        sgtk.util.filesystem.ensure_folder_exists(folder)
         if os.path.exists(filepath):
             os.remove(filepath)
 
@@ -259,7 +259,7 @@ class _LinuxCertificateHandler(_CertificateHandler):
 
         # Ensure that the Chrome certificate registry folder exists
         logger.info("Ensuring Chrome certificate registry folder '%s' exists.", self._PKI_DB_PATH)
-        sgtk.util.ensure_folder_exists(self._PKI_DB_PATH)
+        sgtk.util.filesystem.ensure_folder_exists(self._PKI_DB_PATH)
 
         # If the Chrome certificate registry is empty, create it. If there is already a database in
         # there, the folder won't be empty.


### PR DESCRIPTION
Chrome 59 on Mac breaks browser integration because our certificate doesn't report the correct certificate version. Version 3 of the certificate is the one that accepts X509 extensions.

We're updating the framework here to allow an app or engine to regenerate the certificate on demande.

This should be code reviewed in tandem with [this](https://github.com/shotgunsoftware/tk-desktop/pull/76).