### PR TITLE
For #43032: Fixes for PYTHONPATH and Python intepreter paths.

### DIFF
--- a/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
@@ -255,7 +255,7 @@ if __name__ == "__main__":
     with open(arg_data_file, "rb") as fh:
         arg_data = cPickle.load(fh)
 
-    sys.path.extend(arg_data["sys_path"])
+    sys.path = arg_data["sys_path"] + sys.path
 
     cache(
         arg_data["cache_file"],

--- a/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
@@ -255,7 +255,7 @@ if __name__ == "__main__":
     with open(arg_data_file, "rb") as fh:
         arg_data = cPickle.load(fh)
 
-    sys.path = arg_data["sys_path"]
+    sys.path.extend(arg_data["sys_path"])
 
     cache(
         arg_data["cache_file"],

--- a/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
@@ -352,7 +352,7 @@ if __name__ == "__main__":
     with open(arg_data_file, "rb") as fh:
         arg_data = cPickle.load(fh)
 
-    sys.path = arg_data["sys_path"]
+    sys.path.extend(arg_data["sys_path"])
     LOGGING_PREFIX = arg_data["logging_prefix"]
 
     execute(

--- a/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
@@ -352,7 +352,7 @@ if __name__ == "__main__":
     with open(arg_data_file, "rb") as fh:
         arg_data = cPickle.load(fh)
 
-    sys.path.extend(arg_data["sys_path"])
+    sys.path = arg_data["sys_path"] + sys.path
     LOGGING_PREFIX = arg_data["logging_prefix"]
 
     execute(


### PR DESCRIPTION
* Ensures usage of the config’s stated Python interpreter.
* Extends sys.path in the cache and command subprocesses to ensure we don’t blow away PYTHONPATH entries.