### PR TITLE
For #45375: Implements asynchronous caching.

### DIFF
--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -784,40 +784,8 @@ class ShotgunAPI(object):
             re-cache actions, but we then prove that the existing cached data
             is still valid.
         """
-        descriptor = config_data["descriptor"]
-        lookup_hash = config_data["lookup_hash"]
-
-        if async:
-            now = time.time()
-            if lookup_hash in self.CACHE_VALIDATED:
-                time_since = now - self.CACHE_VALIDATED[lookup_hash]
-                if time_since < self.CACHE_VALIDATION_INTERVAL:
-                    logger.debug(
-                        "Recaching of data for %s has already been initiated. "
-                        "This thread will exit without triggering a recache of "
-                        "actions for this entry.", lookup_hash
-                    )
-                    return
-                else:
-                    self.CACHE_VALIDATED[lookup_hash] = now
-            else:
-                self.CACHE_VALIDATED[lookup_hash] = now
-
-            logger.debug("Cache actions executing asynchronously...")
-            thread = threading.Thread(
-                target=self._cache_actions,
-                args=(
-                    data,
-                    config_data,
-                    cached_contents_hash,
-                ),
-                kwargs=dict(async=False),
-            )
-            thread.start()
-            logger.debug("Cache actions thread started.")
-            return
-
         logger.debug("Caching engine commands...")
+        descriptor = config_data["descriptor"]
 
         script = os.path.join(
             os.path.dirname(__file__),

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -52,7 +52,7 @@ class ShotgunAPI(object):
         "pick_files_or_directories",
     ]
 
-    # Stores cache keys that have been checked validated and at
+    # Stores cache keys that have been validated and at
     # what time that occurred.
     CACHE_VALIDATED = dict()
     CACHE_VALIDATION_INTERVAL = 2.0 # Seconds
@@ -712,7 +712,7 @@ class ShotgunAPI(object):
         # While core swapping, the Python path is not updated with the new core's Python path,
         # so make sure the current core is at the front of the Python path for our subprocesses.
         python_folder = sgtk.bootstrap.ToolkitManager.get_core_python_path()
-        logger.info("Adding %s to sys.path for subprocesses.", python_folder)
+        logger.debug("Adding %s to sys.path for subprocesses.", python_folder)
         return [python_folder] + sys.path
 
     ###########################################################################

--- a/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
@@ -15,6 +15,7 @@ import os
 import sqlite3
 import contextlib
 import traceback
+import copy
 
 CORE_INFO_COMMAND = "__core_info"
 UPGRADE_CHECK_COMMAND = "__upgrade_check"
@@ -37,9 +38,6 @@ def bootstrap(data, base_configuration, engine_name, config_data, bundle_cache_f
 
     :returns: Bootstrapped engine instance.
     """
-    # The local import of sgtk ensures that it occurs after sys.path is set
-    # to what the server sent over.
-    import sgtk
     sgtk.LogManager().initialize_base_file_handler("tk-shotgun")
 
     logger = sgtk.LogManager.get_logger(LOGGER_NAME)
@@ -257,7 +255,25 @@ if __name__ == "__main__":
     with open(arg_data_file, "rb") as fh:
         arg_data = cPickle.load(fh)
 
-    sys.path = sys.path + arg_data["sys_path"]
+    # We do this in two steps. The first is to prepend to sys.path
+    # before immediately importing sgtk. After that, we replace the
+    # prepend with an append. This allows us to guarantee that we
+    # have sgtk imported from the right place, followed by setting
+    # up sys.path the way that is safest for other imports.
+    original_sys_path = copy.copy(sys.path)
+
+    try:
+        # The RPC api that spawned us has ensured that the first path
+        # in the sys.path list that it provided us is the root path that
+        # will get us the tk-core that we want. We can't prepend any more
+        # than that, because we might be running in a different version
+        # of Python in this process than SG Desktop is. We don't want to
+        # force Python 2.7 standard library modules to be imported if
+        # we're in Python 2.6 here, as an example.
+        sys.path = [arg_data["sys_path"][0]] + sys.path
+        import sgtk
+    finally:
+        sys.path = original_sys_path + arg_data["sys_path"]
 
     cache(
         arg_data["cache_file"],

--- a/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
@@ -255,25 +255,15 @@ if __name__ == "__main__":
     with open(arg_data_file, "rb") as fh:
         arg_data = cPickle.load(fh)
 
-    # We do this in two steps. The first is to prepend to sys.path
-    # before immediately importing sgtk. After that, we replace the
-    # prepend with an append. This allows us to guarantee that we
-    # have sgtk imported from the right place, followed by setting
-    # up sys.path the way that is safest for other imports.
+    # The RPC api has given us the path to its tk-core to prepend
+    # to our sys.path prior to importing sgtk. We'll prepent the
+    # the path, import sgtk, and then clean up after ourselves.
     original_sys_path = copy.copy(sys.path)
-
     try:
-        # The RPC api that spawned us has ensured that the first path
-        # in the sys.path list that it provided us is the root path that
-        # will get us the tk-core that we want. We can't prepend any more
-        # than that, because we might be running in a different version
-        # of Python in this process than SG Desktop is. We don't want to
-        # force Python 2.7 standard library modules to be imported if
-        # we're in Python 2.6 here, as an example.
-        sys.path = [arg_data["sys_path"][0]] + sys.path
+        sys.path = [arg_data["sys_path"]] + sys.path
         import sgtk
     finally:
-        sys.path = original_sys_path + arg_data["sys_path"]
+        sys.path = original_sys_path
 
     cache(
         arg_data["cache_file"],

--- a/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
@@ -353,25 +353,15 @@ if __name__ == "__main__":
     with open(arg_data_file, "rb") as fh:
         arg_data = cPickle.load(fh)
 
-    # We do this in two steps. The first is to prepend to sys.path
-    # before immediately importing sgtk. After that, we replace the
-    # prepend with an append. This allows us to guarantee that we
-    # have sgtk imported from the right place, followed by setting
-    # up sys.path the way that is safest for other imports.
+    # The RPC api has given us the path to its tk-core to prepend
+    # to our sys.path prior to importing sgtk. We'll prepent the
+    # the path, import sgtk, and then clean up after ourselves.
     original_sys_path = copy.copy(sys.path)
-
     try:
-        # The RPC api that spawned us has ensured that the first path
-        # in the sys.path list that it provided us is the root path that
-        # will get us the tk-core that we want. We can't prepend any more
-        # than that, because we might be running in a different version
-        # of Python in this process than SG Desktop is. We don't want to
-        # force Python 2.7 standard library modules to be imported if
-        # we're in Python 2.6 here, as an example.
-        sys.path = [arg_data["sys_path"][0]] + sys.path
+        sys.path = [arg_data["sys_path"]] + sys.path
         import sgtk
     finally:
-        sys.path = original_sys_path + arg_data["sys_path"]
+        sys.path = original_sys_path
 
     LOGGING_PREFIX = arg_data["logging_prefix"]
 


### PR DESCRIPTION
Additional changes:
* YML file mtime stats during cache validation is now much deeper than before. We crawl to the bottom of the config's env area.
* A sys.path bug in the caching and execution subprocesses is now resolved. We are now guaranteed to get the correct tk-core imported when the subprocesses are spawned.

The intent of these changes are to address issues raised during client testing (the sys.path issue above), and those found during QA of tk-config-default2 (the yml file mtime depth). The changes to how deep we traverse the config looking for yml files to stat necessitates running the caching validation and potential recache asynchronously. The reason for this is that on slow network storage, the time needed to crawl the config and stat the relevant yml files can be quite slow.

The solution here resolves any speed issues that might arise, but the approach opens us up to a known regression in UX. Because the cache validity is checked asynchronously, the first time a user shows the toolkit menu after a config change, they will receive old data. Subsequent requests for menu actions will then be correct, as the cache will have been updated asynchronously the first time the menu was shown. This is regression that we're willing to accept given the speed benefits of the approach.