### PR TITLE
For #46128, multiple endpoints in toolkit.ini

### DIFF
--- a/framework.py
+++ b/framework.py
@@ -135,6 +135,12 @@ class DesktopserverFramework(sgtk.platform.Framework):
         return os.path.join(self.cache_location, "keys")
 
     def _get_host_aliases(self, host):
+        """
+        Returns a list of valid hosts that can connect to the browser integration. The returned
+        list only contains the hostname. The port number and protocol are removed.
+
+        :returns: List of hostnames.
+        """
         self.logger.debug("Looking for an alias for host %s.", host)
         # parse the host and keep only the network location, no need for the rest.
         parsed_host = urlparse.urlparse(host)
@@ -142,7 +148,7 @@ class DesktopserverFramework(sgtk.platform.Framework):
         # members are not None, in which case we want just the hostname and don't
         # care about the port number. If hostname is not set, then we can grab
         # the network location safely.
-        hostname = parsed_host.hostname or parsed_host.netloc.lower()
+        hostname = (parsed_host.hostname or parsed_host.netloc).lower()
         self.logger.debug("Hostname is %s.", hostname)
 
         # Return the dictionary into a list of pool of aliases. Each list is

--- a/framework.py
+++ b/framework.py
@@ -118,6 +118,7 @@ class DesktopserverFramework(sgtk.platform.Framework):
                 encrypt=encrypt,
                 host=host,
                 user_id=user_id,
+                alternative_hosts=self._settings.alternative_hosts,
                 port=self._settings.port
             )
 
@@ -185,8 +186,21 @@ class DesktopserverFramework(sgtk.platform.Framework):
         self.logger.debug("Retrieving certificates from Shotgun")
         certs = self.shotgun._call_rpc("sg_desktop_certificates", {})
         sgtk.util.filesystem.ensure_folder_exists(self._get_shotgunlocalhost_keys_folder())
-        self._write_cert("server.crt", certs["sg_desktop_cert"])
-        self._write_cert("server.key", certs["sg_desktop_key"])
+        if not certs["sg_desktop_cert"]:
+            self.logger.error(
+                "shotgunlocalhost.com public key is not set in Shotgun. "
+                "Please contact support@shotgunsoftware.com"
+            )
+        else:
+            self._write_cert("server.crt", certs["sg_desktop_cert"])
+
+        if not certs["sg_desktop_key"]:
+            self.logger.error(
+                "shotgunlocalhost.com private key is not set in Shotgun. "
+                "Please contact support@shotgunsoftware.com"
+            )
+        else:
+            self._write_cert("server.key", certs["sg_desktop_key"])
 
     def __ensure_certificate_ready(self, regenerate_certs=False, parent=None):
         """

--- a/python/tk_framework_desktopserver/server.py
+++ b/python/tk_framework_desktopserver/server.py
@@ -36,7 +36,7 @@ class Server(object):
     class Notifier(QtCore.QObject):
         different_user_requested = QtCore.Signal(str, int)
 
-    def __init__(self, keys_path, encrypt, host, user_id, port=None):
+    def __init__(self, keys_path, encrypt, host, user_id, whitelisted_hosts, port=None):
         """
         Constructor.
 
@@ -52,6 +52,7 @@ class Server(object):
         self._keys_path = keys_path or self._DEFAULT_KEYS_PATH
         self._host = host
         self._user_id = user_id
+        self._whitelisted_hosts = whitelisted_hosts
 
         # If encryption is required, compute a server id and retrieve the secret associated to it.
         if encrypt:
@@ -115,6 +116,7 @@ class Server(object):
 
         self.factory.protocol = ServerProtocol
         self.factory.host = self._host
+        self.factory.whitelisted_hosts = self._whitelisted_hosts
         self.factory.user_id = self._user_id
         self.factory.notifier = self.notifier
         self.factory.ws_server_id = self._ws_server_id

--- a/python/tk_framework_desktopserver/server.py
+++ b/python/tk_framework_desktopserver/server.py
@@ -36,7 +36,7 @@ class Server(object):
     class Notifier(QtCore.QObject):
         different_user_requested = QtCore.Signal(str, int)
 
-    def __init__(self, keys_path, encrypt, host, user_id, whitelisted_hosts, port=None):
+    def __init__(self, keys_path, encrypt, host, user_id, alternative_hosts, port=None):
         """
         Constructor.
 
@@ -52,11 +52,13 @@ class Server(object):
         self._keys_path = keys_path or self._DEFAULT_KEYS_PATH
         self._host = host
         self._user_id = user_id
-        self._whitelisted_hosts = whitelisted_hosts
 
+        whitelisted_hosts = [alt_host.lower() for alt_host in alternative_hosts]
         lower_host = host.lower()
         if lower_host not in whitelisted_hosts:
             whitelisted_hosts.append(lower_host)
+
+        self._whitelisted_hosts = whitelisted_hosts
 
         # If encryption is required, compute a server id and retrieve the secret associated to it.
         if encrypt:

--- a/python/tk_framework_desktopserver/server.py
+++ b/python/tk_framework_desktopserver/server.py
@@ -54,6 +54,10 @@ class Server(object):
         self._user_id = user_id
         self._whitelisted_hosts = whitelisted_hosts
 
+        lower_host = host.lower()
+        if lower_host not in whitelisted_hosts:
+            whitelisted_hosts.append(lower_host)
+
         # If encryption is required, compute a server id and retrieve the secret associated to it.
         if encrypt:
             # urandom is considered cryptographically secure as it calls the OS's CSRNG, so we can

--- a/python/tk_framework_desktopserver/server.py
+++ b/python/tk_framework_desktopserver/server.py
@@ -36,7 +36,7 @@ class Server(object):
     class Notifier(QtCore.QObject):
         different_user_requested = QtCore.Signal(str, int)
 
-    def __init__(self, keys_path, encrypt, host, user_id, alternative_hosts, port=None):
+    def __init__(self, keys_path, encrypt, host, user_id, host_aliases, port=None):
         """
         Constructor.
 
@@ -45,6 +45,7 @@ class Server(object):
         :param encrypt: If True, the communication with clients will be encrypted.
         :param host: Url of the host we're expecting requests from.
         :param user_id: Id of the user we're expecting requests from.
+        :param host_aliases: List of aliases available for the current host.
         :param port: Port to listen for websocket requests from.
         :param low_level_debug: If True, wss traffic will be written to the console.
         """
@@ -53,12 +54,7 @@ class Server(object):
         self._host = host
         self._user_id = user_id
 
-        whitelisted_hosts = [alt_host.lower() for alt_host in alternative_hosts]
-        lower_host = host.lower()
-        if lower_host not in whitelisted_hosts:
-            whitelisted_hosts.append(lower_host)
-
-        self._whitelisted_hosts = whitelisted_hosts
+        self._host_aliases = host_aliases
 
         # If encryption is required, compute a server id and retrieve the secret associated to it.
         if encrypt:
@@ -122,7 +118,7 @@ class Server(object):
 
         self.factory.protocol = ServerProtocol
         self.factory.host = self._host
-        self.factory.whitelisted_hosts = self._whitelisted_hosts
+        self.factory.host_aliases = self._host_aliases
         self.factory.user_id = self._user_id
         self.factory.notifier = self.notifier
         self.factory.ws_server_id = self._ws_server_id

--- a/python/tk_framework_desktopserver/server_protocol.py
+++ b/python/tk_framework_desktopserver/server_protocol.py
@@ -247,7 +247,7 @@ class ServerProtocol(WebSocketServerProtocol):
         # The user id is only going to be present with protocol v2.
         if user_id:
             # If we're on the right site and have the correct user, we're fine.
-            if host_network == origin_network and user_id == self.factory.user_id:
+            if origin_network in self.factory.whitelisted_hosts and user_id == self.factory.user_id:
                 return True
             else:
                 # Otherwise report an error and log some stats.
@@ -259,7 +259,7 @@ class ServerProtocol(WebSocketServerProtocol):
                 return False
         else:
             # If we're on the right site when using protocol v1
-            if host_network == origin_network:
+            if origin_network in self.factory.whitelisted_hosts:
                 # we're good to go.
                 return True
             else:

--- a/python/tk_framework_desktopserver/server_protocol.py
+++ b/python/tk_framework_desktopserver/server_protocol.py
@@ -10,6 +10,7 @@
 
 import json
 import datetime
+import urlparse
 
 import OpenSSL
 from cryptography.fernet import Fernet
@@ -242,30 +243,32 @@ class ServerProtocol(WebSocketServerProtocol):
         # origin is formatted such as https://xyz.shotgunstudio.com:port_number
         # host is https://xyz.shotgunstudio.com:port_number
         host_network = self.factory.host.lower()
-        origin_network = self._origin.lower()
+        origin_network = urlparse.urlparse(self._origin).netloc.lower()
 
         # The user id is only going to be present with protocol v2.
         if user_id:
             # If we're on the right site and have the correct user, we're fine.
-            if origin_network in self.factory.whitelisted_hosts and user_id == self.factory.user_id:
+            if origin_network in self.factory.host_aliases and user_id == self.factory.user_id:
                 return True
             else:
                 # Otherwise report an error and log some stats.
                 logger.debug("Browser integration request received a different user.")
                 logger.debug("Desktop site: %s", host_network)
                 logger.debug("Desktop user: %s", self.factory.user_id)
+                logger.debug("Host aliases: %s", self.factory.host_aliases)
                 logger.debug("Origin site: %s", origin_network)
                 logger.debug("Origin user: %s", user_id)
                 return False
         else:
             # If we're on the right site when using protocol v1
-            if origin_network in self.factory.whitelisted_hosts:
+            if origin_network in self.factory.host_aliases:
                 # we're good to go.
                 return True
             else:
                 # Otherwise report an error and log some stats.
                 logger.debug("Browser integration request received a different user.")
                 logger.debug("Desktop site: %s", host_network)
+                logger.debug("Host aliases: %s", self.factory.host_aliases)
                 logger.debug("Origin site: %s", origin_network)
                 return False
 

--- a/python/tk_framework_desktopserver/server_protocol.py
+++ b/python/tk_framework_desktopserver/server_protocol.py
@@ -244,6 +244,10 @@ class ServerProtocol(WebSocketServerProtocol):
         # host is https://xyz.shotgunstudio.com:port_number
         host_network = self.factory.host.lower()
         parsed_host = urlparse.urlparse(self._origin)
+        # When the network location has a port number, the hostname and port
+        # members are not None, in which case we want just the hostname and don't
+        # care about the port number. If hostname is not set, then we can grab
+        # the network location safely.
         origin_network = (parsed_host.hostname or parsed_host.netloc).lower()
 
         # The user id is only going to be present with protocol v2.

--- a/python/tk_framework_desktopserver/server_protocol.py
+++ b/python/tk_framework_desktopserver/server_protocol.py
@@ -243,7 +243,8 @@ class ServerProtocol(WebSocketServerProtocol):
         # origin is formatted such as https://xyz.shotgunstudio.com:port_number
         # host is https://xyz.shotgunstudio.com:port_number
         host_network = self.factory.host.lower()
-        origin_network = urlparse.urlparse(self._origin).netloc.lower()
+        parsed_host = urlparse.urlparse(self._origin)
+        origin_network = (parsed_host.hostname or parsed_host.netloc).lower()
 
         # The user id is only going to be present with protocol v2.
         if user_id:

--- a/python/tk_framework_desktopserver/settings.py
+++ b/python/tk_framework_desktopserver/settings.py
@@ -8,8 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
-import ConfigParser
+import pprint
 
 from . import logger
 
@@ -35,71 +34,60 @@ class Settings(object):
     _PORT_SETTING = "port"
     _CERTIFICATE_FOLDER_SETTING = "certificate_folder"
     _ENABLED = "enabled"
-    _ALTERNATIVE_HOSTS = "alternative_hosts"
+    _HOST_ALIASES = "HostAliases"
 
-    def __init__(self, location, default_certificate_folder):
+    def __init__(self, default_certificate_folder):
         """
         Constructor.
 
         If the configuration file doesn't not exist, the configuration
         object will return the default values.
 
-        :param location: Path to the configuration file. If ``None``, Toolkit's sgtk.util.UserSettings module
-            will be used instead to retrieve the values.
         :param default_certificate_folder: Default location for the certificate file. This value
             is overridable for each app that can use this settings object.
         """
 
         self._default_certificate_folder = default_certificate_folder
 
-        # Retrieve all the settings from the configuration file or the Tookit UserSettings object.
-        if location is not None:
-            config = self._load_config(location)
-            port = self._get_value(
-                config, self._PORT_SETTING, int
-            )
-            certificate_folder = self._get_value(
-                config, self._CERTIFICATE_FOLDER_SETTING
-            )
-            integration_enabled = self._get_value(
-                config, self._ENABLED
-            )
-            alternative_hosts = self._get_value(
-                config, self._ALTERNATIVE_HOSTS
-            )
-        else:
-            from sgtk.util import UserSettings
-            user_settings = UserSettings()
-            port = user_settings.get_integer_setting(
-                self._BROWSER_INTEGRATION, self._PORT_SETTING
-            )
-            certificate_folder = user_settings.get_setting(
-                self._BROWSER_INTEGRATION, self._CERTIFICATE_FOLDER_SETTING
-            )
-            integration_enabled = UserSettings().get_boolean_setting(self._BROWSER_INTEGRATION, self._ENABLED)
-            alternative_hosts = UserSettings().get_setting(self._BROWSER_INTEGRATION, self._ALTERNATIVE_HOSTS)
+        from sgtk.util import UserSettings
+        user_settings = UserSettings()
+        port = user_settings.get_integer_setting(
+            self._BROWSER_INTEGRATION, self._PORT_SETTING
+        )
+        certificate_folder = user_settings.get_setting(
+            self._BROWSER_INTEGRATION, self._CERTIFICATE_FOLDER_SETTING
+        )
+        integration_enabled = UserSettings().get_boolean_setting(self._BROWSER_INTEGRATION, self._ENABLED)
+
+        raw_host_aliases = {}
+        if UserSettings().get_section_settings(self._HOST_ALIASES):
+            raw_host_aliases = {
+                name: UserSettings().get_setting(
+                    self._HOST_ALIASES, name
+                )
+                for name in UserSettings().get_section_settings(self._HOST_ALIASES)
+            }
 
         self._port = port or self._DEFAULT_PORT
         self._certificate_folder = certificate_folder or self._default_certificate_folder
         self._integration_enabled = integration_enabled
 
+        # Keep the raw aliases for support, but filter the settings for API users.
+        self._raw_host_aliases = raw_host_aliases
+        self._host_aliases = {}
         # Ensure we have a string, and then split the string on commas, make sure we're stripping
         # out beginning and end of string whitespaces and then lowercase everything.
-        self._alternative_hosts = (alternative_hosts or "").split(",")
-        self._alternative_hosts = [host.lower().strip() for host in self._alternative_hosts]
+        # Also skip empty tokens.
+        for main_host, secondary_hosts in raw_host_aliases.iteritems():
+            main_host = main_host.strip().lower()
+            # Skip empty hosts.
+            if not main_host:
+                continue
 
-    def _load_config(self, path):
-        """
-        Loads the configuration at a given location and returns it.
-
-        :param path: Path to the configuration to load.
-
-        :returns: A ConfigParser instance with the contents from the configuration file.
-        """
-        config = ConfigParser.SafeConfigParser()
-        if os.path.exists(path):
-            config.read(path)
-        return config
+            self._host_aliases[main_host] = [
+                secondary_host.lower().strip()
+                for secondary_host in secondary_hosts.split(",")
+            ]
 
     @property
     def port(self):
@@ -123,14 +111,14 @@ class Settings(object):
         return self._certificate_folder
 
     @property
-    def alternative_hosts(self):
+    def host_aliases(self):
         """
         Alternative hosts that are allowed to connect to the browser integration.
 
         This is an expert setting and should only be used when dealing with separate endpoints
         for API access and webapp access.
         """
-        return self._alternative_hosts
+        return self._host_aliases
 
     def dump(self, logger):
         """
@@ -139,39 +127,4 @@ class Settings(object):
         logger.debug("Integration enabled: %s" % self.integration_enabled)
         logger.debug("Certificate folder: %s" % self.certificate_folder)
         logger.debug("Port: %d" % self.port)
-        logger.debug("Alternative hosts: %s" % self.alternative_hosts)
-
-    def _get_value(self, config, key, type_cast=str):
-        """
-        Retrieves a value from the config.ini file. If the value is not set, returns the default.
-        Since all values are strings inside the file, you can optionally cast the data to another type.
-
-        :param config: Configuration parser holding the settings.
-        :param section: Section (name between brackets) of the setting.
-        :param key: Name of the setting within a section.
-        ;param type_cast: Casts the value to the passed in type. Defaults to str.
-        :param default: If the value is not found, returns this default value. Defauts to None.
-
-        :returns: The appropriately type casted value if the value is found, default otherwise.
-        """
-        section = self._BROWSER_INTEGRATION
-        if config.has_section(section) and config.has_option(section, key):
-            return type_cast(self._resolve_value(config, section, key))
-        else:
-            return None
-
-    def _resolve_value(self, config, section, key):
-        """
-        Resolves a value in the file and translates any environment variable or ~ present.
-
-        :param config: Configuration parser holding the settings.
-        :param section: Name of the section of the value.
-        :param key: Key of the value to retrieve for the selection section.
-
-        :returns: Value with ~ and any environment variable resolved.
-        """
-        return os.path.expandvars(
-            os.path.expanduser(
-                config.get(section, key)
-            )
-        )
+        logger.debug("Host aliases: %s" % pprint.pformat(self._raw_host_aliases))

--- a/python/tk_framework_desktopserver/settings.py
+++ b/python/tk_framework_desktopserver/settings.py
@@ -35,6 +35,7 @@ class Settings(object):
     _PORT_SETTING = "port"
     _CERTIFICATE_FOLDER_SETTING = "certificate_folder"
     _ENABLED = "enabled"
+    _WHITELISTED_HOSTS = "whitelisted_hosts"
 
     def __init__(self, location, default_certificate_folder):
         """
@@ -63,6 +64,9 @@ class Settings(object):
             integration_enabled = self._get_value(
                 config, self._ENABLED
             )
+            whitelisted_hosts = self._get_value(
+                config, self._WHITELISTED_HOSTS
+            )
         else:
             from sgtk.util import UserSettings
             user_settings = UserSettings()
@@ -73,10 +77,12 @@ class Settings(object):
                 self._BROWSER_INTEGRATION, self._CERTIFICATE_FOLDER_SETTING
             )
             integration_enabled = UserSettings().get_boolean_setting(self._BROWSER_INTEGRATION, self._ENABLED)
+            whitelisted_hosts = UserSettings().get_string(self._BROWSER_INTEGRATION, self._WHITELISTED_HOSTS)
 
         self._port = port or self._DEFAULT_PORT
         self._certificate_folder = certificate_folder or self._default_certificate_folder
         self._integration_enabled = integration_enabled
+        self._whitelisted_hosts = whitelisted_hosts
 
     def _load_config(self, path):
         """
@@ -111,6 +117,10 @@ class Settings(object):
         :returns: Path to the certificate location.
         """
         return self._certificate_folder
+
+    @property
+    def whitelisted_hosts(self):
+        return self._whitelisted_hosts
 
     def dump(self, logger):
         """

--- a/tests/api_v2/test_cache.py
+++ b/tests/api_v2/test_cache.py
@@ -12,10 +12,6 @@ import os
 import sys
 
 from tank_test.tank_test_base import setUpModule
-
-# import the test base class
-test_python_path = os.path.abspath(os.path.join( os.path.dirname(__file__), "..", "python"))
-sys.path.append(test_python_path)
 from base_test import TestDesktopServerFramework, MockConfigDescriptor
 
 class TestCacheMethods(TestDesktopServerFramework):

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -64,11 +64,11 @@ class TestServerBase:
             self,
             use_encryption=False,
             origin="https://site.shotgunstudio.com",
-            whitelisted_hosts=None
+            host_aliases=None
         ):
 
-            if not whitelisted_hosts:
-                whitelisted_hosts = ["https://site.shotgunstudio.com"]
+            if not host_aliases:
+                host_aliases = ["site.shotgunstudio.com"]
 
             self._use_encryption = use_encryption
 
@@ -110,7 +110,7 @@ class TestServerBase:
                 encrypt=use_encryption,
                 host="https://site.shotgunstudio.com",
                 user_id=self._user["id"],
-                whitelisted_hosts=whitelisted_hosts,
+                host_aliases=host_aliases,
                 port=9000
             )
 
@@ -548,7 +548,7 @@ class TestInvalidOriginBase:
             return self.setUpClientServer(
                 use_encryption=self.use_encryption,
                 origin=self.origin,
-                whitelisted_hosts=self.whitelisted_hosts
+                host_aliases=self.host_aliases
             )
 
         def test_origin(self):
@@ -595,14 +595,14 @@ class TestInvalidOriginEncrypted(TestInvalidOriginBase.Impl):
     should_fail = True
     use_encryption = True
     origin = "https://altsite.shotgunstudio.com"
-    whitelisted_hosts = []
+    host_aliases = []
 
 
 class TestValidOriginEncrypted(TestInvalidOriginBase.Impl):
     should_fail = False
     use_encryption = True
     origin = "https://altsite.shotgunstudio.com"
-    whitelisted_hosts = ["https://altsite.shotgunstudio.com"]
+    host_aliases = ["altsite.shotgunstudio.com"]
 
 
 class TestInvalidOriginUnencrypted(TestInvalidOriginEncrypted):

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -558,16 +558,19 @@ class TestInvalidOriginBase:
                     encrypt=self._use_encryption
                 )
 
+            def stepFailure(payload):
+                self.assertEqual(
+                    payload,
+                    (
+                        3001,
+                        "You are not authorized to make browser integration "
+                        "requests. Please re-authenticate in your desktop application."
+                    )
+                )
+
             def step2(payload):
                 if self.should_fail:
-                    self.assertEqual(
-                        payload,
-                        (
-                            3001,
-                            "You are not authorized to make browser integration "
-                            "requests. Please re-authenticate in your desktop application."
-                        )
-                    )
+                    stepFailure(payload)
                 else:
                     self.assertFalse(isinstance(payload, tuple))
 
@@ -580,8 +583,10 @@ class TestInvalidOriginBase:
                         {"value": "hellohellohello"}
                     )
 
+            # When using encryption, we won't even be able to enable it because we'll
+            # be on the wrong side. So move straight away to the failure step.
             if self._use_encryption and self.should_fail:
-                return self._chain_calls(self._activate_encryption_if_required, step2)
+                return self._chain_calls(self._activate_encryption_if_required, stepFailure)
             else:
                 return self._chain_calls(self._activate_encryption_if_required, step1, step2)
 

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -57,262 +57,269 @@ class MockShotgunApi(object):
         self._host.reply({"value": payload["value"] * 3})
 
 
-class TestServerBase(unittest.TestCase):
-    def setUpClientServer(self, use_encryption=False, origin="https://site.shotgunstudio.com", whitelisted_hosts=None):
+class TestServerBase:
 
-        if not whitelisted_hosts:
-            whitelisted_hosts = ["https://site.shotgunstudio.com"]
+    class Impl(unittest.TestCase):
+        def setUpClientServer(
+            self,
+            use_encryption=False,
+            origin="https://site.shotgunstudio.com",
+            whitelisted_hosts=None
+        ):
 
-        self._use_encryption = use_encryption
+            if not whitelisted_hosts:
+                whitelisted_hosts = ["https://site.shotgunstudio.com"]
 
-        # Create a mockgun instance and add support for the _call_rpc method which is used to get
-        # the secret.
-        sg_host = "https://127.0.0.1"
-        Shotgun.set_schema_paths(
-            os.path.join(fixtures_root, "mockgun", "schema.pickle"),
-            os.path.join(fixtures_root, "mockgun", "schema_entity.pickle")
-        )
-        self._mockgun = Shotgun(sg_host)
-        self._mockgun._call_rpc = self._call_rpc
-        self._mockgun.server_info = {
-            "shotgunlocalhost_browser_integration_enabled": True
-        }
+            self._use_encryption = use_encryption
 
-        # Set up an encryption key.
-        self._ws_server_secret = base64.urlsafe_b64encode(os.urandom(32))
-
-        self._fernet = Fernet(self._ws_server_secret)
-
-        # Create the user who will be making all the requests.
-        self._user = self._mockgun.create("HumanUser", {"name": "Gilles Pomerleau"})
-
-        # Pretend there is a current bundle loaded.
-        patched = patch("sgtk.platform.current_bundle", return_value=Mock(shotgun=self._mockgun))
-        patched.start()
-        self.addCleanup(patched.stop)
-
-        from tk_framework_desktopserver import Server, shotgun
-
-        patched = patch.object(Server, "Notifier", new=Mock())
-        patched.start()
-        self.addCleanup(patched.stop)
-
-        # Initialize the websocket server.
-        self.server = Server(
-            keys_path=os.path.join(fixtures_root, "certificates"),
-            encrypt=use_encryption,
-            host="https://site.shotgunstudio.com",
-            user_id=self._user["id"],
-            whitelisted_hosts=whitelisted_hosts,
-            port=9000
-        )
-
-        patched = patch.object(
-            shotgun, "get_shotgun_api",
-            new=lambda _, host, process_manager, wss_key: MockShotgunApi(host, process_manager, wss_key)
-        )
-        patched.start()
-        self.addCleanup(patched.stop)
-
-        # Do not call server.start() as this will also launch the reactor, which was already
-        # launched by twisted.trial
-        self.server._start_server()
-
-        # Create the client connection to the websocket server.
-        context_factory = ssl.DefaultOpenSSLContextFactory(
-            os.path.join(fixtures_root, "certificates", "server.key"),
-            os.path.join(fixtures_root, "certificates", "server.crt")
-        )
-
-        # This will be returned by the setUp method to signify that we're done setuping the test.
-        connection_ready_deferred = Deferred()
-        test_case = self
-
-        class ClientProtocol(WebSocketClientProtocol):
-            """
-            This class will use Deferred instances to notify that the test is ready to start
-            and to notify the test that a payload has arrived.
-            """
-            def __init__(self):
-                super(ClientProtocol, self).__init__()
-                self._on_message_deferred = None
-
-            def onConnect(self, response):
-                """
-                Informs the unit test framework that we're connected to the server.
-                """
-                test_case.client_protocol = self
-                connection_ready_deferred.callback(None)
-
-            def sendMessage(self, payload, is_binary):
-                """
-                Sends a message to the websocket server.
-
-                :returns: A deferred that will be called when the associated response comes back.
-
-                .. note::
-                    Only one message can be sent at a time at the moment.
-                """
-                super(ClientProtocol, self).sendMessage(payload, isBinary=is_binary)
-                self._on_message_deferred = Deferred()
-                return self._on_message_deferred
-
-            def _get_deferred(self):
-                """
-                Retrieves the current deferred and clears it from the client.
-                """
-                d = self._on_message_deferred
-                self._on_message_deferred = None
-                return d
-
-            def onMessage(self, payload, is_binary):
-                """
-                Invokes any callback attached to the last Deferred returned by sendMessage.
-                """
-                self._get_deferred().callback(payload)
-
-            def onClose(self, was_clean, code, reason):
-                # Only report clean closure, since they are the ones initiated by the server.
-                if was_clean:
-                    self._get_deferred().callback((code, reason))
-
-        # Create the websocket connection to the server.
-        client_factory = WebSocketClientFactory("wss://localhost:9000")
-        client_factory.origin = origin
-        client_factory.protocol = ClientProtocol
-        self.client = connectWS(client_factory, context_factory, timeout=2)
-
-        # When the test ends, we need to stop listening.
-        self.addCleanup(lambda: self.client.disconnect())
-        self.addCleanup(lambda: self.server._observer.stop())
-        self.addCleanup(lambda: self.server.listener.stopListening())
-
-        # Return the deferred that will be called then the setup is completed.
-        return connection_ready_deferred
-
-    def _call_rpc(self, name, paylad, *args):
-        """
-        Implements the retrieval of the websocket server secret.
-        """
-        if name == "retrieve_ws_server_secret":
-            return {
-                "ws_server_secret": self._ws_server_secret
+            # Create a mockgun instance and add support for the _call_rpc method which is used to get
+            # the secret.
+            sg_host = "https://127.0.0.1"
+            Shotgun.set_schema_paths(
+                os.path.join(fixtures_root, "mockgun", "schema.pickle"),
+                os.path.join(fixtures_root, "mockgun", "schema_entity.pickle")
+            )
+            self._mockgun = Shotgun(sg_host)
+            self._mockgun._call_rpc = self._call_rpc
+            self._mockgun.server_info = {
+                "shotgunlocalhost_browser_integration_enabled": True
             }
-        else:
-            raise NotImplementedError("The RPC %s is not implemented." % name)
 
-    def _chain_calls(self, *calls):
-        """
-        This will chain calls to the websocket server. Each method must follow this pattern:
+            # Set up an encryption key.
+            self._ws_server_secret = base64.urlsafe_b64encode(os.urandom(32))
 
-            def method(result):
-                d = Deferred()
-                ...
-                return d
+            self._fernet = Fernet(self._ws_server_secret)
 
-        The last method must not return.
+            # Create the user who will be making all the requests.
+            self._user = self._mockgun.create("HumanUser", {"name": "Gilles Pomerleau"})
 
-        If the test doesn't complete under 5 seconds, it will be aborted.
+            # Pretend there is a current bundle loaded.
+            patched = patch("sgtk.platform.current_bundle", return_value=Mock(shotgun=self._mockgun))
+            patched.start()
+            self.addCleanup(patched.stop)
 
-        :returns: The Deferred that will be invoked when the test succeeds or fails.
-        """
-        done = Deferred()
-        done.addTimeout(5, reactor)
-        self._call_next(None, list(calls), done)
-        return done
+            from tk_framework_desktopserver import Server, shotgun
 
-    def _call_next(self, payload, calls, done):
-        """
-        Calls the next method in the calls array. Calls ``done`` when there is an error
-        or all the calls have been executed.
-        """
-        try:
-            # Invoke the next method in the chain.
-            method = calls.pop(0)
-            d = method(payload)
+            patched = patch.object(Server, "Notifier", new=Mock())
+            patched.start()
+            self.addCleanup(patched.stop)
 
-            # If we got a Deferred back
-            if d and len(calls) == 0:
-                # Make sure there are more calls to make
-                done.errback(RuntimeError("Got a Deferred, but call chain is empty."))
-            elif not d and len(calls) != 0:
-                # If we don't have a deferred as a result, simply call the next method.
-                self._call_next(None, calls, done)
-                return
+            # Initialize the websocket server.
+            self.server = Server(
+                keys_path=os.path.join(fixtures_root, "certificates"),
+                encrypt=use_encryption,
+                host="https://site.shotgunstudio.com",
+                user_id=self._user["id"],
+                whitelisted_hosts=whitelisted_hosts,
+                port=9000
+            )
 
-            # If a deferred is returned, we must invoke the remaining calls when the deferred
-            # is signaled.
-            if d:
-                d.addCallback(lambda payload: self._call_next(payload, calls, done))
+            patched = patch.object(
+                shotgun, "get_shotgun_api",
+                new=lambda _, host, process_manager, wss_key: MockShotgunApi(host, process_manager, wss_key)
+            )
+            patched.start()
+            self.addCleanup(patched.stop)
+
+            # Do not call server.start() as this will also launch the reactor, which was already
+            # launched by twisted.trial
+            self.server._start_server()
+
+            # Create the client connection to the websocket server.
+            context_factory = ssl.DefaultOpenSSLContextFactory(
+                os.path.join(fixtures_root, "certificates", "server.key"),
+                os.path.join(fixtures_root, "certificates", "server.crt")
+            )
+
+            # This will be returned by the setUp method to signify that we're done setuping the test.
+            connection_ready_deferred = Deferred()
+            test_case = self
+
+            class ClientProtocol(WebSocketClientProtocol):
+                """
+                This class will use Deferred instances to notify that the test is ready to start
+                and to notify the test that a payload has arrived.
+                """
+                def __init__(self):
+                    super(ClientProtocol, self).__init__()
+                    self._on_message_deferred = None
+
+                def onConnect(self, response):
+                    """
+                    Informs the unit test framework that we're connected to the server.
+                    """
+                    test_case.client_protocol = self
+                    connection_ready_deferred.callback(None)
+
+                def sendMessage(self, payload, is_binary):
+                    """
+                    Sends a message to the websocket server.
+
+                    :returns: A deferred that will be called when the associated response comes back.
+
+                    .. note::
+                        Only one message can be sent at a time at the moment.
+                    """
+                    super(ClientProtocol, self).sendMessage(payload, isBinary=is_binary)
+                    self._on_message_deferred = Deferred()
+                    return self._on_message_deferred
+
+                def _get_deferred(self):
+                    """
+                    Retrieves the current deferred and clears it from the client.
+                    """
+                    d = self._on_message_deferred
+                    self._on_message_deferred = None
+                    return d
+
+                def onMessage(self, payload, is_binary):
+                    """
+                    Invokes any callback attached to the last Deferred returned by sendMessage.
+                    """
+                    self._get_deferred().callback(payload)
+
+                def onClose(self, was_clean, code, reason):
+                    # Only report clean closure, since they are the ones initiated by the server.
+                    if was_clean:
+                        self._get_deferred().callback((code, reason))
+
+            # Create the websocket connection to the server.
+            client_factory = WebSocketClientFactory("wss://localhost:9000")
+            client_factory.origin = origin
+            client_factory.protocol = ClientProtocol
+            self.client = connectWS(client_factory, context_factory, timeout=2)
+
+            # When the test ends, we need to stop listening.
+            self.addCleanup(lambda: self.client.disconnect())
+            self.addCleanup(lambda: self.server._observer.stop())
+            self.addCleanup(lambda: self.server.listener.stopListening())
+
+            # Return the deferred that will be called then the setup is completed.
+            return connection_ready_deferred
+
+        def _call_rpc(self, name, paylad, *args):
+            """
+            Implements the retrieval of the websocket server secret.
+            """
+            if name == "retrieve_ws_server_secret":
+                return {
+                    "ws_server_secret": self._ws_server_secret
+                }
             else:
-                # We didn't get a Deferred and it was the last method, so invoke the done deferred
-                # to tell the test case we're done.
-                done.callback(None)
-        except Exception as e:
-            # There was an error, abort the test right now!
-            done.errback(e)
+                raise NotImplementedError("The RPC %s is not implemented." % name)
 
-    def _send_payload(self, payload, encrypt=False, is_binary=False):
-        """
-        Sends a payload as is to the server.
-        """
-        if encrypt:
-            payload = self._fernet.encrypt(payload)
-        return self.client_protocol.sendMessage(payload, is_binary)
+        def _chain_calls(self, *calls):
+            """
+            This will chain calls to the websocket server. Each method must follow this pattern:
 
-    def _send_message(self, command, data, encrypt=False, is_binary=False, protocol_version=2, user_id=None):
-        """
-        Sends a message to the websocket server in the expected format.
-        """
-        payload = {
-            "id": 1,
-            "protocol_version": protocol_version,
+                def method(result):
+                    d = Deferred()
+                    ...
+                    return d
 
-            "command": {
-                "name": command,
-                "data": {
-                    "user": {
-                        "entity": {
-                            "id": user_id or self._user["id"]
+            The last method must not return.
+
+            If the test doesn't complete under 5 seconds, it will be aborted.
+
+            :returns: The Deferred that will be invoked when the test succeeds or fails.
+            """
+            done = Deferred()
+            done.addTimeout(5, reactor)
+            self._call_next(None, list(calls), done)
+            return done
+
+        def _call_next(self, payload, calls, done):
+            """
+            Calls the next method in the calls array. Calls ``done`` when there is an error
+            or all the calls have been executed.
+            """
+            try:
+                # Invoke the next method in the chain.
+                method = calls.pop(0)
+                d = method(payload)
+
+                # If we got a Deferred back
+                if d and len(calls) == 0:
+                    # Make sure there are more calls to make
+                    done.errback(RuntimeError("Got a Deferred, but call chain is empty."))
+                elif not d and len(calls) != 0:
+                    # If we don't have a deferred as a result, simply call the next method.
+                    self._call_next(None, calls, done)
+                    return
+
+                # If a deferred is returned, we must invoke the remaining calls when the deferred
+                # is signaled.
+                if d:
+                    d.addCallback(lambda payload: self._call_next(payload, calls, done))
+                else:
+                    # We didn't get a Deferred and it was the last method, so invoke the done deferred
+                    # to tell the test case we're done.
+                    done.callback(None)
+            except Exception as e:
+                # There was an error, abort the test right now!
+                done.errback(e)
+
+        def _send_payload(self, payload, encrypt=False, is_binary=False):
+            """
+            Sends a payload as is to the server.
+            """
+            if encrypt:
+                payload = self._fernet.encrypt(payload)
+            return self.client_protocol.sendMessage(payload, is_binary)
+
+        def _send_message(self, command, data, encrypt=False, is_binary=False, protocol_version=2, user_id=None):
+            """
+            Sends a message to the websocket server in the expected format.
+            """
+            payload = {
+                "id": 1,
+                "protocol_version": protocol_version,
+
+                "command": {
+                    "name": command,
+                    "data": {
+                        "user": {
+                            "entity": {
+                                "id": user_id or self._user["id"]
+                            }
                         }
                     }
                 }
             }
-        }
-        if data:
-            payload["command"]["data"].update(data)
-        return self._send_payload(
-            json.dumps(payload),
-            encrypt=encrypt
-        )
+            if data:
+                payload["command"]["data"].update(data)
+            return self._send_payload(
+                json.dumps(payload),
+                encrypt=encrypt
+            )
 
-    def _is_error(self, payload, msg):
-        """
-        Asserts if a payload is an error message.
-        """
-        self.assertEqual(payload.get("error", False), True)
-        self.assertTrue(
-            payload["error_message"].startswith(msg),
-            "'%s' does not start with '%s'" % (payload["error_message"], msg)
-        )
+        def _is_error(self, payload, msg):
+            """
+            Asserts if a payload is an error message.
+            """
+            self.assertEqual(payload.get("error", False), True)
+            self.assertTrue(
+                payload["error_message"].startswith(msg),
+                "'%s' does not start with '%s'" % (payload["error_message"], msg)
+            )
 
-    def _is_not_error(self, payload):
-        self.assertNotIn("error", payload)
+        def _is_not_error(self, payload):
+            self.assertNotIn("error", payload)
 
-    def _activate_encryption_if_required(self, _):
-        """
-        Activate encryption if this test suite needs it.
-        """
-        if self._use_encryption:
-            return self._activate_encryption(_)
-        else:
-            return None
+        def _activate_encryption_if_required(self, _):
+            """
+            Activate encryption if this test suite needs it.
+            """
+            if self._use_encryption:
+                return self._activate_encryption(_)
+            else:
+                return None
 
-    def _activate_encryption(self, _):
-        """
-        Activates encryption
-        """
-        return self._send_message("get_ws_server_id", None)
+        def _activate_encryption(self, _):
+            """
+            Activates encryption
+            """
+            return self._send_message("get_ws_server_id", None)
 
 
 def CommonTestsMetaClass(class_name, class_parents, class_attr):
@@ -457,84 +464,84 @@ def CommonTestsMetaClass(class_name, class_parents, class_attr):
     return type(class_name, class_parents, class_attr)
 
 
-# class TestEncryptedServer(TestServerBase):
-#     """
-#     Tests for various caching-related methods for api_v2.
-#     """
-#     __metaclass__ = CommonTestsMetaClass
+class TestEncryptedServer(TestServerBase.Impl):
+    """
+    Tests for various caching-related methods for api_v2.
+    """
+    __metaclass__ = CommonTestsMetaClass
 
-#     def setUp(self):
-#         super(TestEncryptedServer, self).setUp()
-#         return self.setUpClientServer(use_encryption=True)
+    def setUp(self):
+        super(TestEncryptedServer, self).setUp()
+        return self.setUpClientServer(use_encryption=True)
 
-#     def test_calls_encrypted(self):
-#         """
-#         Ensures that calls are encrypted after get_ws_server_is is invoked.
-#         """
-#         def step1(payload):
-#             return self._send_message("repeat_value", {"value": "hello"}, encrypt=True)
+    def test_calls_encrypted(self):
+        """
+        Ensures that calls are encrypted after get_ws_server_is is invoked.
+        """
+        def step1(payload):
+            return self._send_message("repeat_value", {"value": "hello"}, encrypt=True)
 
-#         def step2(payload):
-#             payload = self._fernet.decrypt(payload)
-#             payload = json.loads(payload)
-#             self._is_not_error(payload)
-#             self.assertEqual(payload["reply"]["value"], "hellohellohello")
+        def step2(payload):
+            payload = self._fernet.decrypt(payload)
+            payload = json.loads(payload)
+            self._is_not_error(payload)
+            self.assertEqual(payload["reply"]["value"], "hellohellohello")
 
-#             # Same call without encryption should fail.
-#             return self._send_message("repeat_value", {"value": "hello"})
+            # Same call without encryption should fail.
+            return self._send_message("repeat_value", {"value": "hello"})
 
-#         def step3(payload):
-#             payload = self._fernet.decrypt(payload)
-#             payload = json.loads(payload)
-#             self._is_error(payload, "There was an error while decrypting the message:")
+        def step3(payload):
+            payload = self._fernet.decrypt(payload)
+            payload = json.loads(payload)
+            self._is_error(payload, "There was an error while decrypting the message:")
 
-#         return self._chain_calls(self._activate_encryption, step1, step2, step3)
+        return self._chain_calls(self._activate_encryption, step1, step2, step3)
 
-#     def test_rpc_before_encrypt(self):
-#         """
-#         Calling an RPC before doing the encryption handshake should not work.
-#         """
-#         def step1(payload):
-#             return self._send_message("repeat_value", None)
+    def test_rpc_before_encrypt(self):
+        """
+        Calling an RPC before doing the encryption handshake should not work.
+        """
+        def step1(payload):
+            return self._send_message("repeat_value", None)
 
-#         def step2(payload):
-#             self.assertEqual(
-#                 payload,
-#                 (3002, "Attempted to communicate without completing encryption handshake.")
-#             )
+        def step2(payload):
+            self.assertEqual(
+                payload,
+                (3002, "Attempted to communicate without completing encryption handshake.")
+            )
 
-#         return self._chain_calls(step1, step2)
+        return self._chain_calls(step1, step2)
 
 
-# class TestUnencryptedServer(TestServerBase):
-#     """
-#     Tests for various caching-related methods for api_v2.
-#     """
+class TestUnencryptedServer(TestServerBase.Impl):
+    """
+    Tests for various caching-related methods for api_v2.
+    """
 
-#     __metaclass__ = CommonTestsMetaClass
+    __metaclass__ = CommonTestsMetaClass
 
-#     def setUp(self):
-#         super(TestUnencryptedServer, self).setUp()
-#         return self.setUpClientServer(use_encryption=False)
+    def setUp(self):
+        super(TestUnencryptedServer, self).setUp()
+        return self.setUpClientServer(use_encryption=False)
 
-#     def test_get_ws_server_id_failure(self):
-#         """
-#         Ensures get_ws_server_id does not work when not in encryption mode.
-#         """
-#         def step1(_):
-#             return self._send_message("get_ws_server_id", None)
+    def test_get_ws_server_id_failure(self):
+        """
+        Ensures get_ws_server_id does not work when not in encryption mode.
+        """
+        def step1(_):
+            return self._send_message("get_ws_server_id", None)
 
-#         def step2(payload):
-#             self.assertEqual(
-#                 payload,
-#                 (3003, "Client asked for server id when encryption is not supported.")
-#             )
+        def step2(payload):
+            self.assertEqual(
+                payload,
+                (3003, "Client asked for server id when encryption is not supported.")
+            )
 
-#         return self._chain_calls(step1, step2)
+        return self._chain_calls(step1, step2)
 
 
 class TestInvalidOriginBase:
-    class Impl(TestServerBase):
+    class Impl(TestServerBase.Impl):
 
         def setUp(self):
             super(TestInvalidOriginBase.Impl, self).setUp()
@@ -593,11 +600,8 @@ class TestValidOriginEncrypted(TestInvalidOriginBase.Impl):
     whitelisted_hosts = ["https://altsite.shotgunstudio.com"]
 
 
-class TestInvalidOriginUnencrypted(TestInvalidOriginBase.Impl):
-    should_fail = True
+class TestInvalidOriginUnencrypted(TestInvalidOriginEncrypted):
     use_encryption = False
-    origin = "https://altsite.shotgunstudio.com"
-    whitelisted_hosts = []
 
 
 class TestValidOriginUnencrypted(TestValidOriginEncrypted):

--- a/tests/settings/__init__.py
+++ b/tests/settings/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2018 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -86,12 +86,10 @@ class TestFrameworkWithUserSettings(ShotgunTestBase):
 
 
 class TestAliasesLookup(TestDesktopServerFramework):
-    """
-    Tests that alias extracting from the host_aliases dict works.
-    """
-
     def test_host_aliases_parsing(self):
-
+        """
+        Tests that the aliases list generated from the alias dict is generated as intended.
+        """
         self.framework._settings = SealedMock(
             host_aliases={
                 "www.site.com": ["alt.site.com"]

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2018 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
 import os
 import sys
 from mock import Mock
@@ -18,15 +28,37 @@ from tk_framework_desktopserver import Settings
 
 
 class TestFrameworkWithUserSettings(ShotgunTestBase):
+    """
+    Tests that the Settings objects works properly.
+    """
 
-    def test_no_host_aliases_section(self):
+    def test_default_browser_integration_settings(self):
         """
-        Make sure empty settings file is reported an empty.
+        Make sure browser integrations settings have good default values.
         """
         settings = Settings(None)
+        self.assertEqual(settings.port, 9000)
+        self.assertEqual(settings.certificate_folder, None)
+        self.assertEqual(settings.integration_enabled, True)
         self.assertDictEqual(settings.host_aliases, {})
 
-    def test_filtered_aliases(self):
+    def test_browser_integration_settings(self):
+        """
+        Makes sure browser integration settings are read properly from disk.
+        """
+        self.write_toolkit_ini_file(
+            BrowserIntegration={
+                "port": 9001,
+                "certificate_folder": "/a/b/c",
+                "enabled": False
+            })
+
+        settings = Settings(None)
+        self.assertEqual(settings.port, 9001)
+        self.assertEqual(settings.certificate_folder, "/a/b/c")
+        self.assertEqual(settings.integration_enabled, False)
+
+    def test_host_aliases(self):
         """
         Make sure the settings are filtered correctly.
         """
@@ -54,6 +86,9 @@ class TestFrameworkWithUserSettings(ShotgunTestBase):
 
 
 class TestAliasesLookup(TestDesktopServerFramework):
+    """
+    Tests that alias extracting from the host_aliases dict works.
+    """
 
     def test_host_aliases_parsing(self):
 

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -1,0 +1,77 @@
+import os
+import sys
+from mock import Mock
+
+from base_test import TestDesktopServerFramework
+from tank_test.tank_test_base import setUpModule # noqa
+from tank_test.tank_test_base import ShotgunTestBase, SealedMock
+
+import sgtk
+# Mock Qt since we don't have it.
+sgtk.platform.qt.QtCore = Mock()
+sgtk.platform.qt.QtGui = Mock()
+
+repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, os.path.join(repo_root, "python"))
+
+from tk_framework_desktopserver import Settings
+
+
+class TestFrameworkWithUserSettings(ShotgunTestBase):
+
+    def test_no_host_aliases_section(self):
+        """
+        Make sure empty settings file is reported an empty.
+        """
+        settings = Settings(None)
+        self.assertDictEqual(settings.host_aliases, {})
+
+    def test_filtered_aliases(self):
+        """
+        Make sure the settings are filtered correctly.
+        """
+        self.write_toolkit_ini_file(
+            HostAliases={
+                "site.with.spaces.AND.CAPS ":
+                    " alt.site.with.spaces.AND.CAPS, another.alt.site.with.spaces.AND.CAPS ",
+                "site.without.aliases": ""
+            }
+        )
+
+        settings = Settings(None)
+
+        # Make sure spaces and caps have been removed, as well as empty entries.
+        self.assertDictEqual(
+            settings.host_aliases,
+            {
+                "site.with.spaces.and.caps": [
+                    "alt.site.with.spaces.and.caps",
+                    "another.alt.site.with.spaces.and.caps"
+                ],
+                "site.without.aliases": [""]
+            }
+        )
+
+
+class TestAliasesLookup(TestDesktopServerFramework):
+
+    def test_host_aliases_parsing(self):
+
+        self.framework._settings = SealedMock(
+            host_aliases={
+                "www.site.com": ["alt.site.com"]
+            }
+        )
+
+        for site in ["https://alt.site.com", "https://www.site.com",
+                     "https://alt.site.com:8888", "https://www.site.com:8888"]:
+
+            self.assertEqual(
+                self.framework._get_host_aliases(site),
+                ["www.site.com", "alt.site.com"]
+            )
+
+        self.assertEqual(
+            self.framework._get_host_aliases("https://www.unknown.site.com"),
+            ["www.unknown.site.com"]
+        )


### PR DESCRIPTION
Certain locally hosted clients have multiple endpoints for Shotgun. For example, they might set up an endpoint for webapp access and another one for API access, allowing them to spread the query load on multiple servers.

This becomes an issue because a Shotgun user browsing `https://localshotgunserver` but who uses the `https://localapiserver` with the Shotgun Desktop will not be able to answer browser integration requests, since the names won't match.

To accomodate that setup, we're introducing a list of `HostAliases` to toolkit.ini, which allows to define a list of mappings beween a host and other endpoints. Here's an example:

```
[HostAliases]
localhostserver=localapiserver,localapiserver2
```

This would allow a Shotgun Desktop running the site config on `localapiserver` or `localapiserver2` to still be able to answer browser integrationr requests from localhostserver.


> Note that the tests are currently failing because I'm leveraging functionality that hasn't been merged in tk-core's master branch. This is one of those cases where I say "Trust me, it works on my machine." :)