### PR TITLE
SG-4611: Better error handling around local file link opening, and more debug logging.

### DIFF
--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -669,8 +669,14 @@ class ShotgunAPI(object):
             # happen, but in the cases we're attempting to debug it shouldn't be the 
             # case.
             if filepath is None:
-                logger.warning("Shotgun requested a file open via local file linking, "
+                logger.warning(
+                    "Shotgun requested a file open via local file linking, "
                     "but the provided file path is None."
+                )
+            else:
+                logger.debug(
+                    "Shotgun requested a file open via local file linking. "
+                    "The file path is: %s", filepath
                 )
 
             if local_storages is None:

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -660,6 +660,26 @@ class ShotgunAPI(object):
             # a sane exception is raised later on when the existence of the path is
             # checked.
             filepath = data.get("filepath", "")
+            local_storages = data.get("local_storages")
+
+            # Logging here is for debugging purposes. We have a situation where some
+            # clients are reporting errors when opening files from Shotgun, and the
+            # error implies that we're getting a null value for the file path passed
+            # down from the web app. There are reasonable situations where this might
+            # happen, but in the cases we're attempting to debug it shouldn't be the 
+            # case.
+            if filepath is None:
+                logger.warning("Shotgun requested a file open via local file linking, "
+                    "but the provided file path is None."
+                )
+
+            if local_storages is None:
+                logger.debug(
+                    "Local storages were not provided by Shotgun for the current file open request."
+                )
+            else:
+                logger.debug("Local storages were reported by Shotgun: %s", local_storages)
+
             result = self.process_manager.open(filepath)
 
             # Send back information regarding the success of the operation.

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -655,8 +655,11 @@ class ShotgunAPI(object):
         :param dict data: Message payload.
         """
         try:
-            # Retrieve filepath.
-            filepath = data.get("filepath")
+            # Retrieve filepath. We should always get something in the payload, but if
+            # we didn't for some reason, passing on an empty string will ensure that
+            # a sane exception is raised later on when the existence of the path is
+            # checked.
+            filepath = data.get("filepath", "")
             result = self.process_manager.open(filepath)
 
             # Send back information regarding the success of the operation.
@@ -665,6 +668,7 @@ class ShotgunAPI(object):
 
             self.host.reply(reply)
         except Exception, e:
+            logger.exception(e)
             self.host.report_error(e.message)
 
     def pick_file_or_directory(self, data):


### PR DESCRIPTION
We're in the process of trying to debug an intermittent local file link open bug that we're having trouble reproducing on our end. The plan right now is to handle the error case more gracefully than before, plus log additional information about which local storages the page making the open request had access to at the time the request was made.