### PR TITLE
For SG-4623, software with multiple projects are not actionable

### DIFF
--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -1632,7 +1632,7 @@ class ShotgunAPI(object):
         # We'll deepcopy the data before returning it. That will ensure that
         # any destructive operations on the contents won't bubble up to the
         # cache.
-        return cache[self.SOFTWARE_ENTITIES]
+        return copy.deepcopy(cache[self.SOFTWARE_ENTITIES])
 
     @sgtk.LogManager.log_timing
     def _get_task_parent_entity_type(self, task_id):

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -949,6 +949,15 @@ class ShotgunAPI(object):
         del self._cache[self.PIPELINE_CONFIGS]
 
     def _filter_software_entities_by_project(self, sw_entities, project):
+        """
+        Filter software entities such that only the ones accessible
+        from the given project will be returned.
+
+        :param list sw_entities: List of entity software dictionaries
+        :param dict project: Entity dictionary of the project to select for.
+
+        :returns: List of entity software available for the given project.
+        """
         project_software = []
 
         for sw in sw_entities:

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -959,13 +959,15 @@ class ShotgunAPI(object):
             # entities. If a Software entity's projects list is empty, then there
             # is no filtering to be done, as it's accepted by all projects.
             for sw in associated_sw:
-                for sw_project in sw.get("projects", []):
-                    if sw_project["id"] != project["id"]:
-                        logger.debug("Action %s filtered out due to SW entity projects.", action)
-                        filtered.append(action)
-                        break
-                if action in filtered:
-                    break
+                # Create a list of ids for the project restriction of this software.
+                sw_project_ids = [sw_project["id"] for sw_project in sw.get("projects", [])]
+
+                # If a software has no project restriction it will not filter out an action.
+                # If it does and the current project is not part of the restricted
+                # list of projects then it will be filtered out.
+                if sw_project_ids and project["id"] not in sw_project_ids:
+                    logger.debug("Action %s filtered out due to SW entity: %s", action, sw_project)
+                    filtered.append(action)
 
         return [a for a in actions if a not in filtered]
 

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -1006,7 +1006,8 @@ class ShotgunAPI(object):
             # the information necessary to register the launcher. If the action
             # doesn't include that key, then it means the underlying engine
             # command did not provide that property, and as such is not a
-            # launcher.
+            # launcher. Similarly, if it's set to None then the same applies
+            # and we don't need to test this action for filtering purposes.
             if "engine_name" not in action:
                 project_actions.append(action)
             # Great, we now know we have a launcher action.
@@ -1014,7 +1015,12 @@ class ShotgunAPI(object):
             # launch app being used which allows to accurately filter out actions
             elif "software_entity_id" in action:
                 # If the action comes from one of the available software, we're good to go!
-                if any(action["software_entity_id"] == s["id"] for s in sw_entities):
+                # Also, if the software entity id is missing, this means this a legacy instance
+                # of the launch app.
+                if (
+                    action["software_entity_id"] is None or
+                    any(action["software_entity_id"] == sw["id"] for sw in sw_entities)
+                ):
                     project_actions.append(action)
                 else:
                     logger.debug("Action %s filtered out due to no SW entity with matching id.", action)

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -61,7 +61,7 @@ class ShotgunAPI(object):
     WSS_KEY_CACHE = dict()
     DATABASE_FORMAT_VERSION = 1
     # When the layout of the cache in a cache entry changes, bump this version
-    # so we invalid all cached entries.
+    # so we invalidate all cached entries.
     CACHE_ENTRY_SCHEMA_VERSION = 1
     SOFTWARE_FIELDS = ["id", "code", "updated_at", "type", "engine", "projects"]
     TOOLKIT_MANAGER = None
@@ -1947,8 +1947,9 @@ class ShotgunAPI(object):
                             app_name=None, # Not used here.
                             group=None, # Not used here.
                             group_default=None, # Not used here.
-                            # engine_name is skipped because we don't know if this
-                            # is a legacy launch app.
+                            # this is an old fashioned cache, which means it doesn't have
+                            # software entity information, so we won't cache the engine
+                            # name either
                         )
                     )
             except Exception:

--- a/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
@@ -167,20 +167,26 @@ def cache(
         else:
             app_name = None
 
-        commands.append(
-            dict(
-                name=cmd_name,
-                title=props.get("title", cmd_name),
-                deny_permissions=props.get("deny_permissions", []),
-                supports_multiple_selection=props.get(
-                    "supports_multiple_selection",
-                    False
-                ),
-                app_name=app_name,
-                group=props.get("group"),
-                group_default=props.get("group_default"),
-                engine_name=props.get("engine_name"),
+        command_data = dict(
+            name=cmd_name,
+            title=props.get("title", cmd_name),
+            deny_permissions=props.get("deny_permissions", []),
+            supports_multiple_selection=props.get(
+                "supports_multiple_selection",
+                False
             ),
+            app_name=app_name,
+            group=props.get("group"),
+            group_default=props.get("group_default")
+        )
+        if "engine_name" in props:
+            command_data["engine_name"] = props["engine_name"]
+
+        if "software_entity_id" in props:
+            command_data["software_entity_id"] = props["software_entity_id"]
+
+        commands.append(
+            command_data
         )
 
     engine.log_debug("Engine commands processed.")

--- a/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/cache_commands.py
@@ -179,9 +179,13 @@ def cache(
             group=props.get("group"),
             group_default=props.get("group_default")
         )
+
+        # If the action isn't coming from the launch app, do not even bother putting the engine_name
+        # in the hash. This simplifies the filtering process.
         if "engine_name" in props:
             command_data["engine_name"] = props["engine_name"]
-
+        # If the launch app supported the software_entity_id property, we should save it in the
+        # command's data as well so we can use it to do proper filtering of actions.
         if "software_entity_id" in props:
             command_data["software_entity_id"] = props["software_entity_id"]
 

--- a/tests/api_v2/test_util_methods.py
+++ b/tests/api_v2/test_util_methods.py
@@ -212,7 +212,7 @@ class TestUtilMethods(TestDesktopServerFramework):
         Software entity settings.
         """
         sw = dict(
-            code="Tester",
+            code="Maya",
             engine="tk-maya",
             id=7,
             type="Software",
@@ -221,7 +221,7 @@ class TestUtilMethods(TestDesktopServerFramework):
         self.add_to_sg_mock_db([sw])
 
         sw = dict(
-            code="Maya",
+            code="Nuke",
             engine="tk-nuke",
             id=7,
             type="Software",

--- a/tests/api_v2/test_util_methods.py
+++ b/tests/api_v2/test_util_methods.py
@@ -13,9 +13,6 @@ import sys
 
 from tank_test.tank_test_base import setUpModule # noqa
 
-# import the test base class
-test_python_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "python"))
-sys.path.append(test_python_path)
 from base_test import TestDesktopServerFramework, MockConfigDescriptor
 
 

--- a/tests/api_v2/test_util_methods.py
+++ b/tests/api_v2/test_util_methods.py
@@ -220,6 +220,15 @@ class TestUtilMethods(TestDesktopServerFramework):
         )
         self.add_to_sg_mock_db([sw])
 
+        sw = dict(
+            code="Maya",
+            engine="tk-maya",
+            id=7,
+            type="Software",
+            projects=[],
+        )
+        self.add_to_sg_mock_db([sw])
+
         actions = [
             dict(
                 title="This one passes",

--- a/tests/api_v2/test_util_methods.py
+++ b/tests/api_v2/test_util_methods.py
@@ -8,9 +8,6 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
-import sys
-
 from tank_test.tank_test_base import setUpModule # noqa
 
 from base_test import TestDesktopServerFramework, MockConfigDescriptor
@@ -219,7 +216,7 @@ class TestUtilMethods(TestDesktopServerFramework):
             engine="tk_engine_tester",
             id=7,
             type="Software",
-            projects=[dict(type="Project", id=999), dict(type="Project", id=1000)],
+            projects=[dict(type="Project", id=999)],
         )
         self.add_to_sg_mock_db([sw])
 
@@ -277,14 +274,14 @@ class TestUtilMethods(TestDesktopServerFramework):
             )
         ]
 
-        # filtered_actions = self.api._filter_by_project(
-        #     actions,
-        #     self.api._get_software_entities(),
-        #     dict(type="Project", id=1),
-        # )
+        filtered_actions = self.api._filter_by_project(
+            actions,
+            self.api._get_software_entities(),
+            dict(type="Project", id=1),
+        )
 
         # Project 1 shouldn't match anything.
-        # self.assertEqual(filtered_actions, [])
+        self.assertEqual(filtered_actions, [])
 
         filtered_actions = self.api._filter_by_project(
             actions,

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -13,6 +13,8 @@ import os
 import sys
 import base64
 import json
+import contextlib
+import socket
 
 from mock import patch, Mock
 
@@ -42,6 +44,17 @@ from cryptography.fernet import Fernet
 
 from twisted.internet import base
 base.DelayedCall.debug = True
+
+
+# Source: https://stackoverflow.com/a/45690594/10429444
+def find_free_port():
+    """
+    Finds a free port on the current computer.
+    """
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind(('localhost', 0))
+        return s.getsockname()[1]
 
 
 class MockShotgunApi(object):
@@ -103,6 +116,8 @@ class TestServerBase(unittest.TestCase):
         patched.start()
         self.addCleanup(patched.stop)
 
+        port = find_free_port()
+
         # Initialize the websocket server.
         self.server = Server(
             keys_path=os.path.join(fixtures_root, "certificates"),
@@ -110,7 +125,7 @@ class TestServerBase(unittest.TestCase):
             host="https://site.shotgunstudio.com",
             user_id=self._user["id"],
             host_aliases=host_aliases,
-            port=12345
+            port=port
         )
 
         patched = patch.object(
@@ -183,7 +198,7 @@ class TestServerBase(unittest.TestCase):
                     self._get_deferred().callback((code, reason))
 
         # Create the websocket connection to the server.
-        client_factory = WebSocketClientFactory("wss://localhost:12345")
+        client_factory = WebSocketClientFactory("wss://localhost:%s" % port)
         client_factory.origin = origin
         client_factory.protocol = ClientProtocol
         self.client = connectWS(client_factory, context_factory, timeout=2)

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -554,7 +554,7 @@ class TestUnencryptedServer(TestServerBase):
         return self._chain_calls(step1, step2)
 
 
-class TestDifferentHostBase():
+class DifferentHostBase(object):
     """
     Tests a connection from a different host. The server needs to be launched in different modes,
     but this can only be done during setUp due to the way twisted unit tests work.
@@ -565,7 +565,8 @@ class TestDifferentHostBase():
     """
     class Impl(TestServerBase):
         def setUp(self):
-            super(TestDifferentHostBase.Impl, self).setUp()
+            super(DifferentHostBase.Impl, self).setUp()
+            print(self.__class__)
             return self.setUpClientServer(
                 use_encryption=self.use_encryption,
                 origin=self.origin,
@@ -612,7 +613,7 @@ class TestDifferentHostBase():
                 return self._chain_calls(self._activate_encryption_if_required, step_send_message, step_validation)
 
 
-class TestInvalidOriginEncrypted(TestDifferentHostBase.Impl):
+class TestInvalidOriginEncrypted(DifferentHostBase.Impl):
     """
     Make sure that a different origin will fail when encryption is on.
     """
@@ -629,7 +630,7 @@ class TestInvalidOriginUnencrypted(TestInvalidOriginEncrypted):
     use_encryption = False
 
 
-class TestValidOriginEncrypted(TestDifferentHostBase.Impl):
+class TestValidOriginEncrypted(DifferentHostBase.Impl):
     """
     Make sure that using an alias will succeed when encryption is on.
     """

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -110,7 +110,7 @@ class TestServerBase(unittest.TestCase):
             host="https://site.shotgunstudio.com",
             user_id=self._user["id"],
             host_aliases=host_aliases,
-            port=9000
+            port=12345
         )
 
         patched = patch.object(
@@ -183,7 +183,7 @@ class TestServerBase(unittest.TestCase):
                     self._get_deferred().callback((code, reason))
 
         # Create the websocket connection to the server.
-        client_factory = WebSocketClientFactory("wss://localhost:9000")
+        client_factory = WebSocketClientFactory("wss://localhost:12345")
         client_factory.origin = origin
         client_factory.protocol = ClientProtocol
         self.client = connectWS(client_factory, context_factory, timeout=2)


### PR DESCRIPTION
This fixes a bug where software that is assigned to multiple projects always gets filtered out. This happened because the previous code would filter out an action as soon as the project id wouldn't match one the the projects in the list, effectively preventing any combination of project to match.

I've also update the server tests so that they can be run while the Shotgun Desktop is running, since I kept making that mistake.