### PR TITLE
SG-4611: Fixes a server protocol class variable reference.

### DIFF
--- a/python/tk_framework_desktopserver/server_protocol.py
+++ b/python/tk_framework_desktopserver/server_protocol.py
@@ -344,7 +344,7 @@ class ServerProtocol(WebSocketServerProtocol):
             retrieved by the first instance.
         """
         # Has the server secret already been retrieved before?
-        if not self._ws_server_secret:
+        if not ServerProtocol._ws_server_secret:
             # Ask for the secret for this server id.
             shotgun = sgtk.platform.current_bundle().shotgun
             # FIXME: Make this method public on the Shotgun API.
@@ -357,9 +357,9 @@ class ServerProtocol(WebSocketServerProtocol):
             if ws_server_secret[-1] != "=":
                 ws_server_secret += "="
 
-            self._ws_server_secret = ws_server_secret
+            ServerProtocol._ws_server_secret = ws_server_secret
 
-        return self._ws_server_secret
+        return ServerProtocol._ws_server_secret
 
     def _process_message(self, message_host, message, protocol_version):
 


### PR DESCRIPTION
This caused the server secret to be retrieved every time a protocol object was instantiated, rather than it being retrieved only once and reused. I'll add more information here after we've tested the change relative to a specific bug we're trying to track down.