### PR TITLE
SG-14617: Partial Python 3 support for tk-desktop

### DIFF
--- a/framework.py
+++ b/framework.py
@@ -12,7 +12,12 @@ import sgtk
 import sys
 import os
 import struct
-import urlparse
+
+try:
+    import urlparse
+except ImportError:
+    import urllib.parse as urlparse
+
 from sgtk.util import LocalFileStorageManager
 
 


### PR DESCRIPTION
Fixes an import that fails under python 3. This framework is loaded but not actually used when launching a project that might be using Python 3, so we only need to fix that import error.

The rest of the code will be ported when we port the site portion of the tk-desktop engine.