### PR TITLE
Switched to using sgtk.util.json.load to avoid unicode in python2

### DIFF
--- a/python/tk_framework_desktopserver/shotgun/scripts/get_commands.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/get_commands.py
@@ -18,6 +18,7 @@ import traceback
 import copy
 
 from sgtk.authentication import deserialize_user
+from sgtk.util import json as sg_json
 
 CORE_INFO_COMMAND = "__core_info"
 UPGRADE_CHECK_COMMAND = "__upgrade_check"
@@ -222,7 +223,7 @@ if __name__ == "__main__":
     arg_data_file = sys.argv[1]
 
     with open(arg_data_file, "rt") as fh:
-        arg_data = json.load(fh)
+        arg_data = sg_json.load(fh)
 
     # The RPC api has given us the path to its tk-core to prepend
     # to our sys.path prior to importing sgtk. We'll prepent the


### PR DESCRIPTION
We were using the regular json module and getting back unicodes. Passing the base_configuration descriptor as unicode was causing issues down the line because we only check against the descriptor being a string, then convert it to a dictionary. The unicode was falling through the cracks and we ended up with unicode when we were expecting a dict. 