### PR TITLE
SG-16894 Null lookup hash in cache

### DIFF
--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -1397,13 +1397,6 @@ class ShotgunAPI(object):
         :returns: A set of lowercased string entity types.
         :rtype: set
         """
-
-        import pydevd_pycharm
-
-        pydevd_pycharm.settrace(
-            "localhost", port=1234, stdoutToServer=True, stderrToServer=True
-        )
-
         if project_id is None:
             logger.debug("Project id is None, looking up site schema.")
             project_entity = None

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -564,6 +564,7 @@ class ShotgunAPI(object):
                     entity["type"],
                     entity["id"],
                 )
+                logger.debug("SG-16894: Calculated lookup hash: %s" % lookup_hash)
             except TankTaskNotLinkedError:
                 # If we're dealing with a Task entity, it needs to be linked
                 # to something. If it's not, then we have nothing to pass
@@ -1003,6 +1004,9 @@ class ShotgunAPI(object):
             # often than we're going to be inserting new rows into the cache,
             # we'll try an update first. If no rows were affected by the update,
             # we move on to an insert.
+            self._engine.log_debug(
+                "SG-16894: Lookup hash search: %s" % config_data["lookup_hash"]
+            )
             cursor.execute(
                 "UPDATE engine_commands SET contents_hash=?, commands=? WHERE lookup_hash=?",
                 (contents_hash, commands_blob, config_data["lookup_hash"]),
@@ -1011,6 +1015,9 @@ class ShotgunAPI(object):
             if cursor.rowcount == 0:
                 self._engine.log_debug(
                     "Update did not result in any rows altered, inserting..."
+                )
+                self._engine.log_debug(
+                    "SG-16894: Lookup hash not found %s" % config_data["lookup_hash"]
                 )
                 cursor.execute(
                     "INSERT INTO engine_commands VALUES (?, ?, ?)",

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -504,6 +504,7 @@ class ShotgunAPI(object):
         # Pass 1: Calculate and store lookup hash on all pipeline configurations
         for pc_id, pc_data in all_pc_data.items():
 
+            pc_data["lookup_hash"] = None
             pipeline_config = pc_data["entity"]
 
             # The hash that acts as the key we'll use to look up our cached

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -557,7 +557,7 @@ class ShotgunAPI(object):
             # because the lookup hash depends on what the specific Task
             # entity we're dealing with is linked to.
             try:
-                lookup_hash = pc_data["lookup_hash"] or self._get_lookup_hash(
+                lookup_hash = pc_data.get("lookup_hash") or self._get_lookup_hash(
                     pc_descriptor.get_uri(),
                     project_entity,
                     entity["type"],

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -504,7 +504,6 @@ class ShotgunAPI(object):
         # Pass 1: Calculate and store lookup hash on all pipeline configurations
         for pc_id, pc_data in all_pc_data.items():
 
-            pc_data["lookup_hash"] = None
             pipeline_config = pc_data["entity"]
 
             # The hash that acts as the key we'll use to look up our cached
@@ -586,13 +585,13 @@ class ShotgunAPI(object):
         with self._db_connect() as (connection, cursor):
             for pc_id, pc_data in all_pc_data.items():
 
-                lookup_hash = pc_data["lookup_hash"]
+                lookup_hash = pc_data.get("lookup_hash")
                 logger.debug("Querying: %s", lookup_hash)
 
                 pc_data["cached_data"] = []
 
                 # If the config doesn't support the current entity_type we don't need to cache it
-                if not lookup_hash:
+                if lookup_hash is None:
                     continue
 
                 try:
@@ -618,12 +617,12 @@ class ShotgunAPI(object):
         for pc_id, pc_data in all_pc_data.items():
             try:
                 cached_data = pc_data["cached_data"]
-                lookup_hash = pc_data["lookup_hash"]
+                lookup_hash = pc_data.get("lookup_hash")
                 pipeline_config = pc_data["entity"]
                 decoded_data = None
 
                 # If the config doesn't support the current entity_type we don't need to cache it
-                if not lookup_hash:
+                if lookup_hash is None:
                     continue
 
                 if cached_data:

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -591,7 +591,7 @@ class ShotgunAPI(object):
 
                 pc_data["cached_data"] = []
 
-                # If the entity is not supported we don't need to cache it
+                # If the config doesn't support the current entity_type we don't need to cache it
                 if not lookup_hash:
                     continue
 
@@ -622,7 +622,7 @@ class ShotgunAPI(object):
                 pipeline_config = pc_data["entity"]
                 decoded_data = None
 
-                # If the entity is not supported we don't need to cache it
+                # If the config doesn't support the current entity_type we don't need to cache it
                 if not lookup_hash:
                     continue
 
@@ -1397,6 +1397,13 @@ class ShotgunAPI(object):
         :returns: A set of lowercased string entity types.
         :rtype: set
         """
+
+        import pydevd_pycharm
+
+        pydevd_pycharm.settrace(
+            "localhost", port=1234, stdoutToServer=True, stderrToServer=True
+        )
+
         if project_id is None:
             logger.debug("Project id is None, looking up site schema.")
             project_entity = None


### PR DESCRIPTION
In my previous commit (which is now merged) I took the single loop that iterates through pipeline configurations and caches the actions and split it into 3 loops. This was done to avoid holding a lock on the cache database the entire time.

Pass 1: Collect the info needed to do a cache lookup for all the configs. 
Pass2: Read the cache for all the keys collected in pass 1
Pass3: Either use the cached value or cache new values for each config

The issue is that when Pass 1 skipped a certain config because it doesn't support the current entity type, in the original code all the rest of the steps would be skipped as well because they were part of the same loop. In the 3 pass setup, the second and third loop were still going through all configs (even the ones that were skipped in the first pass) and we were writing NULL values into the DB and getting stuck in an infinite loop.

This fix makes sure that the other passes also skip the configs that don't support the entity type