### PR TITLE
SG-18619 Fix for incorrect PYTHONPATH when launching Maya

### DIFF
--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -38,24 +38,6 @@ from .. import command
 logger = sgtk.platform.get_logger(__name__)
 
 
-@contextlib.contextmanager
-def tk_in_python_path():
-    """
-    Context manager that ensures that Toolkit is in the PYTHONPATH.
-    This is necessary so six and sgtk.util.json can be used early on
-    when launching a subprocess.
-    The PYTHONPATH is restored to it's previous value after the call.
-    :yields: None.
-    """
-    backup = os.environ.get("PYTHONPATH")
-    try:
-        sgtk.util.prepend_path_to_env_var("PYTHONPATH", sgtk.get_sgtk_module_path())
-        yield
-    finally:
-        if backup:
-            os.environ["PYTHONPATH"] = backup
-
-
 ###########################################################################
 # Classes
 
@@ -950,8 +932,7 @@ class ShotgunAPI(object):
         # we protect ourselves from spawning concurrent caching subprocesses
         # that might end up stepping on each other.
         with self._LOCK:
-            with tk_in_python_path():
-                retcode, stdout, stderr = command.Command.call_cmd(args)
+            retcode, stdout, stderr = command.Command.call_cmd(args)
 
         if retcode == 0:
             logger.debug("Command stdout: %s", stdout)

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -302,8 +302,8 @@ class ShotgunAPI(object):
         if sgtk.get_authenticated_user():
             sgtk.get_authenticated_user().refresh_credentials()
 
-        with tk_in_python_path():
-            retcode, stdout, stderr = command.Command.call_cmd(args)
+        # with tk_in_python_path():
+        retcode, stdout, stderr = command.Command.call_cmd(args)
 
         # We need to filter stdout before we send it to the client.
         # We look for lines that we know came from the custom log

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -302,7 +302,6 @@ class ShotgunAPI(object):
         if sgtk.get_authenticated_user():
             sgtk.get_authenticated_user().refresh_credentials()
 
-        # with tk_in_python_path():
         retcode, stdout, stderr = command.Command.call_cmd(args)
 
         # We need to filter stdout before we send it to the client.

--- a/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
@@ -394,7 +394,7 @@ if __name__ == "__main__":
         sys.path = original_sys_path
 
     # Now that we have sgtk.util loaded, use it to make sure we have only utf-8 data in the args
-    arg_data = sgtk.util.json.loads(json.dumps(arg_data))
+    arg_data = sgtk.util.unicode.ensure_contains_str(arg_data)
 
     LOGGING_PREFIX = arg_data["logging_prefix"]
 

--- a/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
@@ -389,8 +389,6 @@ if __name__ == "__main__":
     try:
         sys.path = [arg_data["sys_path"]] + sys.path
         import sgtk
-        import sgtk.util
-        from sgtk.authentication import deserialize_user
         from tank_vendor import six
     finally:
         sys.path = original_sys_path
@@ -408,7 +406,7 @@ if __name__ == "__main__":
         arg_data["base_configuration"],
         arg_data["engine_name"],
         arg_data["bundle_cache_fallback_paths"],
-        deserialize_user(arg_data["user"]),
+        sgtk.authentication.deserialize_user(arg_data["user"]),
     )
 
     sys.exit(0)

--- a/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
@@ -9,10 +9,8 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import sys
-import sgtk.util
-from sgtk.authentication import deserialize_user
-from tank_vendor import six
 import os
+import json
 import logging
 import base64
 import functools
@@ -382,7 +380,7 @@ if __name__ == "__main__":
     arg_data_file = sys.argv[1]
 
     with open(arg_data_file, "rt") as fh:
-        arg_data = sgtk.util.json.load(fh)
+        arg_data = json.load(fh)
 
     # The RPC api has given us the path to its tk-core to prepend
     # to our sys.path prior to importing sgtk. We'll prepent the
@@ -391,8 +389,14 @@ if __name__ == "__main__":
     try:
         sys.path = [arg_data["sys_path"]] + sys.path
         import sgtk
+        import sgtk.util
+        from sgtk.authentication import deserialize_user
+        from tank_vendor import six
     finally:
         sys.path = original_sys_path
+
+    # Now that we have sgtk.util loaded, use it to make sure we have only utf-8 data in the args
+    arg_data = sgtk.util.json.loads(json.dumps(arg_data))
 
     LOGGING_PREFIX = arg_data["logging_prefix"]
 

--- a/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/execute_command.py
@@ -383,7 +383,7 @@ if __name__ == "__main__":
         arg_data = json.load(fh)
 
     # The RPC api has given us the path to its tk-core to prepend
-    # to our sys.path prior to importing sgtk. We'll prepent the
+    # to our sys.path prior to importing sgtk. We'll prepend the
     # the path, import sgtk, and then clean up after ourselves.
     original_sys_path = copy.copy(sys.path)
     try:

--- a/python/tk_framework_desktopserver/shotgun/scripts/get_commands.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/get_commands.py
@@ -10,15 +10,9 @@
 
 from __future__ import print_function
 import sys
-from tank_vendor import six
 import json
-import sqlite3
-import contextlib
 import traceback
 import copy
-
-from sgtk.authentication import deserialize_user
-from sgtk.util import json as sg_json
 
 CORE_INFO_COMMAND = "__core_info"
 UPGRADE_CHECK_COMMAND = "__upgrade_check"
@@ -223,7 +217,7 @@ if __name__ == "__main__":
     arg_data_file = sys.argv[1]
 
     with open(arg_data_file, "rt") as fh:
-        arg_data = sg_json.load(fh)
+        arg_data = json.load(fh)
 
     # The RPC api has given us the path to its tk-core to prepend
     # to our sys.path prior to importing sgtk. We'll prepent the
@@ -235,6 +229,9 @@ if __name__ == "__main__":
     finally:
         sys.path = original_sys_path
 
+    # Now that we have sgtk.util loaded, use it to make sure we have only utf-8 data in the args
+    arg_data = sgtk.util.json.loads(json.dumps(arg_data))
+
     cache(
         arg_data["cache_file"],
         arg_data["output_file"],
@@ -244,7 +241,7 @@ if __name__ == "__main__":
         arg_data["config_data"],
         arg_data["config_is_mutable"],
         arg_data["bundle_cache_fallback_paths"],
-        deserialize_user(arg_data["user"]),
+        sgtk.authentication.deserialize_user(arg_data["user"]),
     )
 
     sys.exit(0)

--- a/python/tk_framework_desktopserver/shotgun/scripts/get_commands.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/get_commands.py
@@ -220,7 +220,7 @@ if __name__ == "__main__":
         arg_data = json.load(fh)
 
     # The RPC api has given us the path to its tk-core to prepend
-    # to our sys.path prior to importing sgtk. We'll prepent the
+    # to our sys.path prior to importing sgtk. We'll prepend the
     # the path, import sgtk, and then clean up after ourselves.
     original_sys_path = copy.copy(sys.path)
     try:

--- a/python/tk_framework_desktopserver/shotgun/scripts/get_commands.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/get_commands.py
@@ -230,7 +230,7 @@ if __name__ == "__main__":
         sys.path = original_sys_path
 
     # Now that we have sgtk.util loaded, use it to make sure we have only utf-8 data in the args
-    arg_data = sgtk.util.json.loads(json.dumps(arg_data))
+    arg_data = sgtk.util.unicode.ensure_contains_str(arg_data)
 
     cache(
         arg_data["cache_file"],


### PR DESCRIPTION
Clients are running into an issue where the PYTHONPATH contains the wrong copy of sgtk in front of the correct one. This means that the wrong hooks will be searched for/loaded when they launch Maya. 

The execute_command file was recently updated to use some core utilities and the imports for these were at the top of the file. To accommodate this, the sgtk path was being added to PYTHONPATH before calling execute_command. 

In this PR I moved sgtk related imports in execute_command to run after we have modified sys.path correctly to include sgtk. At this point there will be no requirement for sgtk to be in the path before calling execute_method so I also removed the addition of sgtk to PYTHONPATH before calling execute_command in api_v2