### PR TITLE
SG-18875: localhost integration fixes under Python 3

### DIFF
--- a/python/tk_framework_desktopserver/certificates.py
+++ b/python/tk_framework_desktopserver/certificates.py
@@ -109,9 +109,9 @@ class _CertificateHandler(object):
         # Chrome deprecated CN matching
         # https://textslashplain.com/2017/03/10/chrome-deprecates-subject-cn-matching/
         # This fixes the issue: http://stackoverflow.com/a/37440167/1074536
-        san_list = ["DNS:localhost"]
+        san_list = [b"DNS:localhost"]
         cert.add_extensions(
-            [crypto.X509Extension("subjectAltName", False, ", ".join(san_list))]
+            [crypto.X509Extension(b"subjectAltName", False, b", ".join(san_list))]
         )
         cert.get_subject().C = "US"
         cert.get_subject().ST = "California"
@@ -199,7 +199,7 @@ class _CertificateHandler(object):
         # The 'security' tool on OSX 10.7 puts everything in upper case, so lower case everything
         # for testing.
         return (
-            "shotgun"
+            b"shotgun"
             in self._check_call(
                 "validating if the certificate was installed",
                 self._get_is_registered_cmd(),
@@ -234,7 +234,7 @@ class _CertificateHandler(object):
         """
         old_umask = os.umask(0o077)
         try:
-            with open(path, "wt") as f:
+            with open(path, "wb") as f:
                 f.write(content)
         finally:
             os.umask(old_umask)

--- a/tests/python/base_test.py
+++ b/tests/python/base_test.py
@@ -46,13 +46,6 @@ class TestDesktopServerFramework(TankTestBase):
         # now make a context
         context = self.tk.context_from_entity(self.project["type"], self.project["id"])
 
-        patched = patch(
-            "sgtk.platform.Engine._define_qt_base",
-            return_value={"qt_core": Mock(), "qt_gui": Mock()},
-        )
-        patched.start()
-        self.addCleanup(patched.stop)
-
         # and start the engine
         self.engine = sgtk.platform.start_engine("test_engine", self.tk, context)
 

--- a/tests/test_certificates.py
+++ b/tests/test_certificates.py
@@ -16,10 +16,12 @@ import sgtk
 from tank_test.tank_test_base import setUpModule, interactive
 from base_test import TestDesktopServerFramework
 
-skip_on_ci = pytest.mark.skipif("CI" in os.environ, reason="These tests require manual intervention to execute.")
+skip_on_ci = pytest.mark.skipif(
+    "CI" in os.environ, reason="These tests require manual intervention to execute."
+)
+
 
 class TestCertificates(TestDesktopServerFramework):
-
     @skip_on_ci
     def test_certificate_creation_flow(self):
         """
@@ -31,11 +33,17 @@ class TestCertificates(TestDesktopServerFramework):
         if QtGui.QApplication.instance() is None:
             self.app = QtGui.QApplication([])
 
-        QtGui.QMessageBox.warning(None, "", "You will be prompted to accept updates to the keychain during this test.")
+        QtGui.QMessageBox.warning(
+            None,
+            "",
+            "You will be prompted to accept updates to the keychain during this test.",
+        )
 
         # Get the certificate handle. We pass in the current test's temporary folder
         # for the location of the cert, which means they do not exist at the moment.
-        handler = self.framework_module.certificates.get_certificate_handler(self.tank_temp)
+        handler = self.framework_module.certificates.get_certificate_handler(
+            self.tank_temp
+        )
 
         # Because certs are registered at the OS level, we need to unregister them first
         # for this test to pass. Unfortunately, this pre-supposes that is_registered and

--- a/tests/test_certificates.py
+++ b/tests/test_certificates.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2020 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+
+from tank_test.tank_test_base import setUpModule, interactive
+from base_test import TestDesktopServerFramework
+
+import pytest
+
+skip_on_ci = pytest.mark.skipif("CI" in os.environ, reason="These tests require manual intervention to execute.")
+
+class TestCertificates(TestDesktopServerFramework):
+
+    @skip_on_ci
+    def test_certificate_creation_flow(self):
+        """
+        Ensure certificates registration and creation work.
+        """
+        # Get the certificate handle. We pass in the current test's temporary folder
+        # for the location of the cert, which means they do not exist at the moment.
+        handler = self.framework_module.certificates.get_certificate_handler(self.tank_temp)
+
+        # Because certs are registered at the OS level, we need to unregister them first
+        # for this test to pass. Unfortunately, this pre-supposes that is_registered and
+        # unregister actually work in the first place for the rest of the test to work.
+        if handler.is_registered():
+            handler.unregister()
+
+        try:
+            # Make sure the certificates are nowhere on disk. That's expected
+            # as we're working from tank_temp.
+            assert handler.exists() is False
+            # No cert should be registered with the OS now.
+            assert handler.is_registered() is False
+            # Let's create the certs and make sure they are now on disk
+            handler.create()
+            assert handler.exists()
+            # However, they should not be registered with the OS at the moment
+            assert handler.is_registered() is False
+            # Now register them
+            handler.register()
+            # and they should be registered.
+            assert handler.is_registered()
+        finally:
+            # Let's unregister them when the test ends, as the person
+            # running the test likely doesn't need them. Most users
+            # use shotgunlocalhost.com
+            handler.unregister()
+

--- a/tests/test_certificates.py
+++ b/tests/test_certificates.py
@@ -34,24 +34,23 @@ class TestCertificates(TestDesktopServerFramework):
         if handler.is_registered():
             handler.unregister()
 
-        try:
-            # Make sure the certificates are nowhere on disk. That's expected
-            # as we're working from tank_temp.
-            assert handler.exists() is False
-            # No cert should be registered with the OS now.
-            assert handler.is_registered() is False
-            # Let's create the certs and make sure they are now on disk
-            handler.create()
-            assert handler.exists()
-            # However, they should not be registered with the OS at the moment
-            assert handler.is_registered() is False
-            # Now register them
-            handler.register()
-            # and they should be registered.
-            assert handler.is_registered()
-        finally:
-            # Let's unregister them when the test ends, as the person
-            # running the test likely doesn't need them. Most users
-            # use shotgunlocalhost.com
-            handler.unregister()
-
+        # Make sure the certificates are nowhere on disk. That's expected
+        # as we're working from tank_temp.
+        assert handler.exists() is False
+        # No cert should be registered with the OS now.
+        assert handler.is_registered() is False
+        # Let's create the certs and make sure they are now on disk
+        handler.create()
+        assert handler.exists()
+        # However, they should not be registered with the OS at the moment
+        assert handler.is_registered() is False
+        # Now register them
+        handler.register()
+        # and they should be registered.
+        assert handler.is_registered()
+        # Now we unregister with the OS.
+        handler.unregister()
+        # It should still exist on disk...
+        assert handler.exists()
+        # ...but not be registered with the OS.
+        assert handler.is_registered() is False

--- a/tests/test_certificates.py
+++ b/tests/test_certificates.py
@@ -10,10 +10,11 @@
 
 import os
 
+import pytest
+import sgtk
+
 from tank_test.tank_test_base import setUpModule, interactive
 from base_test import TestDesktopServerFramework
-
-import pytest
 
 skip_on_ci = pytest.mark.skipif("CI" in os.environ, reason="These tests require manual intervention to execute.")
 
@@ -24,6 +25,14 @@ class TestCertificates(TestDesktopServerFramework):
         """
         Ensure certificates registration and creation work.
         """
+
+        from sgtk.platform.qt import QtGui
+
+        if QtGui.QApplication.instance() is None:
+            self.app = QtGui.QApplication([])
+
+        QtGui.QMessageBox.warning(None, "", "You will be prompted to accept updates to the keychain during this test.")
+
         # Get the certificate handle. We pass in the current test's temporary folder
         # for the location of the cert, which means they do not exist at the moment.
         handler = self.framework_module.certificates.get_certificate_handler(self.tank_temp)


### PR DESCRIPTION
This fixes a set of issues with the certificate registration process under Python 3. I've added a test to reproduce the problem and then fix it. Unfortunately, it can't run on CI as it requires user intervention from the OS. I'm making sure it always run locally at least so this way we get some assurance that it won't be broken.