### PR TITLE
Adds 3.7.9 to the list of Python versions on Azure.

### DIFF
--- a/tests/integration_tests/interpreters.py
+++ b/tests/integration_tests/interpreters.py
@@ -45,7 +45,7 @@ class Python3ProjectTests(SgtkIntegrationTest):
         Get the path to a python interpreter on the current platform that matches the given major version
         """
         azure_python2_versions = ["2.7.18"]
-        azure_python3_versions = ["3.7.7", "3.7.8"]
+        azure_python3_versions = ["3.7.7", "3.7.8", "3.7.9"]
 
         win_paths = {
             2: [r"C:\Program Files\Shotgun\Python\python.exe"],


### PR DESCRIPTION
Azure VMs now have 3.7.9 installed on Windows instead of 3.7.{7,8}, so we're adding it to the list of versions to try.