### PR TITLE
SG-20264 Support URL Update

### DIFF
--- a/framework.py
+++ b/framework.py
@@ -264,13 +264,13 @@ class DesktopserverFramework(sgtk.platform.Framework):
         if not certs["sg_desktop_cert"]:
             self.logger.error(
                 "shotgunlocalhost.com public key is not set in Shotgun. "
-                "Please contact support@shotgunsoftware.com"
+                "Please contact support at {}".format(sgtk.support_url)
             )
 
         if not certs["sg_desktop_key"]:
             self.logger.error(
                 "shotgunlocalhost.com private key is not set in Shotgun. "
-                "Please contact support@shotgunsoftware.com"
+                "Please contact support at {}".format(sgtk.support_url)
             )
 
         # When the shotgun website provides the certificate chain, we'll concatenate

--- a/info.yml
+++ b/info.yml
@@ -26,4 +26,4 @@ description: "Provides the server used to listen to Shotgun client requests, suc
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.19.5"
+requires_core_version: "NEEDS TO BE UPDATED"

--- a/info.yml
+++ b/info.yml
@@ -26,4 +26,4 @@ description: "Provides the server used to listen to Shotgun client requests, suc
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "NEEDS TO BE UPDATED"
+requires_core_version: "v0.19.18"

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -1475,8 +1475,8 @@ class ShotgunAPI(object):
         """
         message = (
             "An unhandled exception has occurred. To see the full error, "
-            "refer to the console in Shotgun Desktop, or contact %s for "
-            "additional help with this issue." % sgtk.constants.SUPPORT_EMAIL
+            "refer to the console in Shotgun Desktop, or contact us via %s for "
+            "additional help with this issue." % sgtk.support_url
         )
 
         if self._global_debug:


### PR DESCRIPTION
Switched to using support_url from tk-core instead of the hard-coded  email address