### PR TITLE
Gracefully dealing with pick_environment returning None

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -10,7 +10,7 @@
 
 # Metadata defining the behavior and requirements for this framework
 
-# expected fields in the configuration file for this engine
+# Expected fields in the configuration file for this engine
 configuration:
     browser_integration_hook:
         type: hook

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -1400,7 +1400,7 @@ class ShotgunAPI(object):
             # environment. Those files contain entity type names that are lower cased,
             # so it's easiest just to do everything that way.
             type_whitelist = set(
-                [t.lower() for t in constants.BASE_ENTITY_TYPE_WHITELIST]
+                [t.lower() for t in constants.BASE_ENTITY_TYPE_ALLOW_LIST]
             )
 
             # This will only ever happen once per unique connection. That means

--- a/python/tk_framework_desktopserver/shotgun/constants.py
+++ b/python/tk_framework_desktopserver/shotgun/constants.py
@@ -22,6 +22,7 @@ COMMAND_FAILED = 1
 
 # Subprocess return codes.
 ENGINE_INIT_ERROR_EXIT_CODE = 77
+UNRESOLVED_ENV_ERROR_EXIT_CORE = 78
 
 # Pipeline configurations.
 OVERRIDE_CONFIG_PATH = os.environ.get("TK_BOOTSTRAP_CONFIG_OVERRIDE")

--- a/python/tk_framework_desktopserver/shotgun/constants.py
+++ b/python/tk_framework_desktopserver/shotgun/constants.py
@@ -42,9 +42,9 @@ PUBLISHED_FILE_ENTITY = "PublishedFile"
 # Once combined with the PublishedFile's entity link types, this
 # forms the list of entity types that we provide action menu items
 # for. Any entity type requesting action menu items that is not in
-# the whitelist is informed that none will be provided.
-BASE_ENTITY_TYPE_WHITELIST = set(
-    ["Project", PUBLISHED_FILE_ENTITY, "Sequence", "Task", "Version",]
+# the allow list is informed that none will be provided.
+BASE_ENTITY_TYPE_ALLOW_LIST = set(
+    ["Project", PUBLISHED_FILE_ENTITY, "Sequence", "Task", "Version", "Playlist"]
 )
 
 # The execute_command.py script creates a custom log handler that

--- a/python/tk_framework_desktopserver/shotgun/scripts/get_commands.py
+++ b/python/tk_framework_desktopserver/shotgun/scripts/get_commands.py
@@ -119,9 +119,9 @@ def cache(
 
         # Try to use a more specific exit code if possible
         try:
-            import tank
+            import sgtk
 
-            if isinstance(e, tank.platform.TankUnresolvedEnvironmentError):
+            if isinstance(e, sgtk.platform.TankUnresolvedEnvironmentError):
                 exit_code = UNRESOLVED_ENV_ERROR_EXIT_CORE
         except Exception:
             pass


### PR DESCRIPTION
When the pick_environment hook returns None, this along with [this PR in tk-core](https://github.com/shotgunsoftware/tk-core/pull/799) will allow us to only show a warning instead of the entire stack trace every time someone navigates to the unsupported entity page in SG. 

The reason behind all of this is related to [this other PR](https://github.com/shotgunsoftware/tk-framework-desktopserver/pull/77)