### PR TITLE
SG-19972 Fix for where we would continue to load actions when the list was empty.

### DIFF
--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -626,7 +626,7 @@ class ShotgunAPI(object):
                         # We've switch to JSON for the Python 3 port.
                         pass
 
-                if decoded_data:
+                if decoded_data is not None:
                     # Cache hit.
                     cached_contents_hash = cached_data[1]
 


### PR DESCRIPTION
If an instance of the tk-shotgun engine was configured with no apps, or the apps didn't show in this particular instance, then it would cause an infinite loop, because we treated an empty list as if we needed to recache the actions.