### PR TITLE
SG-31325 Replace cgi module with the html module to support the escape method.

### DIFF
--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -21,7 +21,7 @@ import base64
 import glob
 import threading
 import hashlib
-import cgi
+import html
 import traceback
 import time
 import fnmatch
@@ -1539,7 +1539,7 @@ class ShotgunAPI(object):
         )
 
         if self._global_debug:
-            message = six.ensure_binary(cgi.escape(traceback.format_exc()))
+            message = six.ensure_binary(html.escape(traceback.format_exc()))
 
         return message
 
@@ -2176,7 +2176,7 @@ class ShotgunAPI(object):
                 line = re.sub(bold_match, "*", line)
                 sanitized.append(line)
 
-        return six.ensure_binary(cgi.escape("\n".join(sanitized)))
+        return six.ensure_binary(html.escape("\n".join(sanitized)))
 
     @sgtk.LogManager.log_timing
     def _process_commands(self, commands, project, entities):

--- a/tests/api_v2/test_util_methods.py
+++ b/tests/api_v2/test_util_methods.py
@@ -443,17 +443,17 @@ class TestUtilMethods(TestDesktopServerFramework):
     @patch("sgtk.log.LogManager.global_debug")
     def test_get_exception_message(self, global_mock):
         """
-        Test unhandled exceptions messages.
+        Test unhandled exception messages.
         """
+        # Mocking debug logging to be True
         manager = sgtk.log.LogManager()
         manager.global_debug = True
         self.assertEqual(manager.global_debug, True)
-
-        expected_msg = (
-                "Exception: Dummy exception"
-        )
+        expected_msg = "Exception: Dummy exception"
+        # Test the traceback 'format_exc' by forcing
+        # an exception.
         try:
             raise Exception("Dummy exception")
-        except Exception as e:
+        except Exception:
             exc_msg = self.api._get_exception_message()
         self.assertEqual(expected_msg in str(exc_msg), True)

--- a/tests/api_v2/test_util_methods.py
+++ b/tests/api_v2/test_util_methods.py
@@ -8,6 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+import sgtk
 from tank_test.tank_test_base import setUpModule  # noqa
 
 from base_test import TestDesktopServerFramework, MockConfigDescriptor
@@ -437,3 +438,11 @@ class TestUtilMethods(TestDesktopServerFramework):
         # Project 1000 can only use the action from tk-nuke and the manually
         # registered one.
         self.assertEqual(filtered_actions, actions[1:])
+
+    def test_get_exception_message(self):
+        """
+        Test unhandled exceptions messages.
+        """
+        manager = sgtk.log.LogManager()
+        manager.global_debug = True
+        self.assertEqual(manager.global_debug, True)

--- a/tests/api_v2/test_util_methods.py
+++ b/tests/api_v2/test_util_methods.py
@@ -8,6 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+from mock import patch
 import sgtk
 from tank_test.tank_test_base import setUpModule  # noqa
 
@@ -439,6 +440,7 @@ class TestUtilMethods(TestDesktopServerFramework):
         # registered one.
         self.assertEqual(filtered_actions, actions[1:])
 
+    @patch("sgtk.log.LogManager.global_debug")
     def test_get_exception_message(self):
         """
         Test unhandled exceptions messages.
@@ -446,3 +448,12 @@ class TestUtilMethods(TestDesktopServerFramework):
         manager = sgtk.log.LogManager()
         manager.global_debug = True
         self.assertEqual(manager.global_debug, True)
+
+        expected_msg = (
+                "Exception: Dummy exception"
+        )
+        try:
+            raise Exception("Dummy exception")
+        except Exception as e:
+            exc_msg = self.api._get_exception_message()
+        self.assertEqual(expected_msg in str(exc_msg), True)

--- a/tests/api_v2/test_util_methods.py
+++ b/tests/api_v2/test_util_methods.py
@@ -441,7 +441,7 @@ class TestUtilMethods(TestDesktopServerFramework):
         self.assertEqual(filtered_actions, actions[1:])
 
     @patch("sgtk.log.LogManager.global_debug")
-    def test_get_exception_message(self):
+    def test_get_exception_message(self, global_mock):
         """
         Test unhandled exceptions messages.
         """

--- a/tests/integration_tests/interpreters.py
+++ b/tests/integration_tests/interpreters.py
@@ -56,6 +56,7 @@ class Python3ProjectTests(SgtkIntegrationTest):
             "3.7.13",
             "3.7.14",
             "3.7.15",
+            "3.7.17",
             "3.9.10",
             "3.9.11",
             "3.9.12",


### PR DESCRIPTION
This PR fix the AttributeError: module 'cgi' has no attribute 'escape', due to the escape method is no longer supported by the cgi module. Also included  Python 3.7.17 to the azure python versions list required by the macOS image in the Azure pipeline.