### PR TITLE
SG-33714 Upgrade Twisted to 23.10.0 for Python 3.9 only

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ jobs:
     extra_test_dependencies:
       # Required to mock tests on Python 3.10
       - attrs==22.2.0
-      - Twisted==23.10.0
+      - Twisted==22.10.0  # We use 22.10.0 to avoid breaking CI for Python 3.7
       - certifi==2023.7.22
       - autobahn==22.12.1
       - pyOpenSSL==23.2.0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ jobs:
     extra_test_dependencies:
       # Required to mock tests on Python 3.10
       - attrs==22.2.0
-      - Twisted==22.10.0
+      - Twisted==23.10.0
       - certifi==2023.7.22
       - autobahn==22.12.1
       - pyOpenSSL==23.2.0

--- a/python/tk_framework_desktopserver/command.py
+++ b/python/tk_framework_desktopserver/command.py
@@ -35,7 +35,7 @@ class ReadThread(Thread):
         :param p_out: Pipe to read.
         :param target_queue: Queue that will accumulate the pipe output.
         """
-        Thread.__init__(self)
+        Thread.__init__(self, daemon=True)
         self.pipe = p_out
         self.target_queue = target_queue
 
@@ -127,11 +127,9 @@ class Command(object):
             stderr_q = Queue()
 
             stdout_t = ReadThread(process.stdout, stdout_q)
-            stdout_t.setDaemon(True)
             stdout_t.start()
 
             stderr_t = ReadThread(process.stderr, stderr_q)
-            stderr_t.setDaemon(True)
             stderr_t.start()
 
             # Popen.communicate() doesn't play nicely if the stdin pipe is closed

--- a/resources/python/requirements/3.7/requirements.txt
+++ b/resources/python/requirements/3.7/requirements.txt
@@ -1,4 +1,4 @@
-Twisted==22.10.0
+Twisted==22.10.0  # This is the last version that supports Python 3.7
 certifi==2023.7.22
 autobahn==22.12.1
 pyOpenSSL==23.2.0

--- a/resources/python/requirements/3.9/requirements.txt
+++ b/resources/python/requirements/3.9/requirements.txt
@@ -1,4 +1,4 @@
-Twisted==22.10.0
+Twisted==23.10.0
 certifi==2023.7.22
 autobahn==22.12.1
 pyOpenSSL==23.2.0


### PR DESCRIPTION
Twisted v23.10.0 stops support for Python 3.7. So we're keeping v22.10.0 for that specific version. We're also keeping that version for CI otherwise it breaks while installing on a Python 3.7 runner)

Resolves #178 
Resolves #184 
Resolves #185

Also, while testing this on CI I found some deprecation warnings on Python 3.10
![Screenshot 2023-11-27 at 11 02 34](https://github.com/shotgunsoftware/tk-framework-desktopserver/assets/123113322/4f9aa081-d2db-44f6-ae28-d7ef3b239065)
