### PR TITLE
Fix Python 3.10 deprecation warning

### DIFF
--- a/python/tk_framework_desktopserver/command.py
+++ b/python/tk_framework_desktopserver/command.py
@@ -35,7 +35,7 @@ class ReadThread(Thread):
         :param p_out: Pipe to read.
         :param target_queue: Queue that will accumulate the pipe output.
         """
-        Thread.__init__(self)
+        Thread.__init__(self, daemon=True)
         self.pipe = p_out
         self.target_queue = target_queue
 
@@ -127,11 +127,9 @@ class Command(object):
             stderr_q = Queue()
 
             stdout_t = ReadThread(process.stdout, stdout_q)
-            stdout_t.setDaemon(True)
             stdout_t.start()
 
             stderr_t = ReadThread(process.stderr, stderr_q)
-            stderr_t.setDaemon(True)
             stderr_t.start()
 
             # Popen.communicate() doesn't play nicely if the stdin pipe is closed


### PR DESCRIPTION
Fix deprecation warnings on Python 3.10
![Screenshot 2023-11-27 at 11 02 34](https://github.com/shotgunsoftware/tk-framework-desktopserver/assets/123113322/4f9aa081-d2db-44f6-ae28-d7ef3b239065)