### PR TITLE
SG-33714 Upgrade Twisted to 23.10.0 for Python 3.9 only

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ jobs:
     extra_test_dependencies:
       # Required to mock tests on Python 3.10
       - attrs==22.2.0
-      - Twisted==22.10.0
+      - Twisted==22.10.0 # We use 22.10.0 to avoid breaking CI for Python 3.7
       - certifi==2023.7.22
       - autobahn==22.12.1
       - pyOpenSSL==23.2.0

--- a/resources/python/requirements/3.7/requirements.txt
+++ b/resources/python/requirements/3.7/requirements.txt
@@ -1,4 +1,4 @@
-Twisted==22.10.0
+Twisted==22.10.0 # This is the last version that supports Python 3.7
 certifi==2023.7.22
 autobahn==22.12.1
 pyOpenSSL==23.2.0

--- a/resources/python/requirements/3.9/requirements.txt
+++ b/resources/python/requirements/3.9/requirements.txt
@@ -1,4 +1,4 @@
-Twisted==22.10.0
+Twisted==23.10.0
 certifi==2023.7.22
 autobahn==22.12.1
 pyOpenSSL==23.2.0


### PR DESCRIPTION
Twisted v23.10.0 stops support for Python 3.7. So we're keeping v22.10.0 for that specific version. We're also keeping that version for CI otherwise it breaks while installing on a Python 3.7 runner)

Resolves https://github.com/shotgunsoftware/tk-framework-desktopserver/pull/178
Resolves https://github.com/shotgunsoftware/tk-framework-desktopserver/pull/184
Resolves https://github.com/shotgunsoftware/tk-framework-desktopserver/pull/185