### PR TITLE
SG-33722 Upgrade cryptography to 41.0.7

### DIFF
--- a/resources/python/requirements/3.7/requirements.txt
+++ b/resources/python/requirements/3.7/requirements.txt
@@ -9,7 +9,7 @@ service_identity==21.1.0
 # modules and rebuild the binaries
 attrs==22.2.0
 cffi==1.15.1
-cryptography==41.0.5
+cryptography==41.0.7
 hyperlink==21.0.0
 idna==3.4
 six==1.16.0

--- a/resources/python/requirements/3.9/requirements.txt
+++ b/resources/python/requirements/3.9/requirements.txt
@@ -9,7 +9,7 @@ service-identity==21.1.0
 # modules and rebuild the binaries
 attrs==22.2.0
 cffi==1.15.1
-cryptography==41.0.5
+cryptography==41.0.7
 hyperlink==21.0.0
 idna==3.4
 six==1.16.0


### PR DESCRIPTION
Please don't confuse it with SG-33306  - #180 #189.

This [new version of cryptography](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#4107---2023-11-27) released yesterday fixes CVE-2023-49083.