### PR TITLE
SG-34279 use manylinux 2.17 whl

### DIFF
--- a/resources/python/pipelines/pipelines.yml
+++ b/resources/python/pipelines/pipelines.yml
@@ -23,7 +23,7 @@ jobs:
       ./install_source_only.sh
       git commit -am "Update source requirements 3.7"
       git push -u origin ${{ parameters.branch }}
-    displayName: Run Scripts
+    displayName: Generate all explicit_requirements & Update source requirements
     workingDirectory: resources/python
 
 - job: install_source_dependencies_3_9
@@ -43,8 +43,10 @@ jobs:
       ./install_source_only.sh
       git commit -am "Update source requirements 3.9"
       git push origin ${{ parameters.branch }}
-    displayName: Run Scripts
+    displayName: Generate all explicit_requirements & Update source requirements
     workingDirectory: resources/python
+
+# ---------------------------------------------
 
 - job: install_binary_dependencies_mac_3_7
   displayName: Install binary dependencies Mac 3.7
@@ -62,7 +64,7 @@ jobs:
       ./install_binary_mac.sh
       git commit -am "Update binary requirements in Mac Python 3.7"
       git push origin ${{ parameters.branch }}
-    displayName: Run Scripts
+    displayName: Update binary requirements
     workingDirectory: resources/python
 
 - job: install_binary_dependencies_mac_3_9
@@ -81,7 +83,7 @@ jobs:
       ./install_binary_mac.sh
       git commit -am "Update binary requirements in Mac Python 3.9"
       git push origin ${{ parameters.branch }}
-    displayName: Run Scripts
+    displayName: Update binary requirements
     workingDirectory: resources/python
 
 - job: install_binary_dependencies_linux_3_7
@@ -100,7 +102,7 @@ jobs:
       ./install_binary_linux.sh
       git commit -am "Update binary requirements in Linux Python 3.7"
       git push origin ${{ parameters.branch }}
-    displayName: Run Scripts
+    displayName: Update binary requirements
     workingDirectory: resources/python
 
 - job: install_binary_dependencies_linux_3_9
@@ -119,7 +121,7 @@ jobs:
       ./install_binary_linux.sh
       git commit -am "Update binary requirements in Linux Python 3.9"
       git push origin ${{ parameters.branch }}
-    displayName: Run Scripts
+    displayName: Update binary requirements
     workingDirectory: resources/python
 
 - job: install_binary_dependencies_windows_3_7
@@ -135,7 +137,7 @@ jobs:
       branch: ${{ parameters.branch }}
   - script: |
       git checkout ${{ parameters.branch }}
-    displayName: Run Scripts
+    displayName: Update binary requirements
     workingDirectory: resources/python
   - powershell: .\install_binary_windows.ps1
     displayName: Run PowerShell Scripts
@@ -159,7 +161,7 @@ jobs:
       branch: ${{ parameters.branch }}
   - script: |
       git checkout ${{ parameters.branch }}
-    displayName: Run Scripts
+    displayName: Update binary requirements
     workingDirectory: resources/python
   - powershell: .\install_binary_windows.ps1
     displayName: Run PowerShell Scripts

--- a/resources/python/pipelines/pipelines.yml
+++ b/resources/python/pipelines/pipelines.yml
@@ -89,7 +89,7 @@ jobs:
   dependsOn: install_source_dependencies_3_9
   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
   pool:
-    vmImage: 'ubuntu-latest'
+    vmImage: 'ubuntu-20.04'
   steps:
   - template: template.yml
     parameters:
@@ -108,7 +108,7 @@ jobs:
   dependsOn: install_binary_dependencies_linux_3_7
   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
   pool:
-    vmImage: 'ubuntu-latest'
+    vmImage: 'ubuntu-20.04'
   steps:
   - template: template.yml
     parameters:

--- a/resources/python/requirements/3.7/requirements.txt
+++ b/resources/python/requirements/3.7/requirements.txt
@@ -15,7 +15,5 @@ six==1.16.0
 zope.interface==5.5.2
 setuptools==65.5.1  # CVE-2022-40897
 
-# Cryptography is a special use case for linux.
-# Default wheels requires GLIBC 2.28 (manylinux_2_28_x86_64) which is not available on CentOS 7.
-cryptography==41.0.7 ; sys_platform != 'linux'
-https://files.pythonhosted.org/packages/14/fd/dd5bd6ab0d12476ebca579cbfd48d31bd90fa28fa257b209df585dcf62a0/cryptography-41.0.7-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; sys_platform == 'linux'
+# We also should have here: cryptography==41.0.7
+# However, for special reasons, see resources/python/update_requirements.py

--- a/resources/python/requirements/3.7/requirements.txt
+++ b/resources/python/requirements/3.7/requirements.txt
@@ -14,6 +14,4 @@ idna==3.4
 six==1.16.0
 zope.interface==5.5.2
 setuptools==65.5.1  # CVE-2022-40897
-
-# We also should have here: cryptography==41.0.7
-# However, for special reasons, see resources/python/update_requirements.py
+cryptography==41.0.7 # Only for SAST. Should be also updated in resources/python/update_requirements.py

--- a/resources/python/requirements/3.7/requirements.txt
+++ b/resources/python/requirements/3.7/requirements.txt
@@ -9,9 +9,13 @@ service_identity==21.1.0
 # modules and rebuild the binaries
 attrs==22.2.0
 cffi==1.15.1
-cryptography==41.0.7
 hyperlink==21.0.0
 idna==3.4
 six==1.16.0
 zope.interface==5.5.2
 setuptools==65.5.1  # CVE-2022-40897
+
+# Cryptography is a special use case for linux.
+# Default wheels requires GLIBC 2.28 (manylinux_2_28_x86_64) which is not available on CentOS 7.
+cryptography==41.0.7 ; sys_platform != 'linux'
+https://files.pythonhosted.org/packages/14/fd/dd5bd6ab0d12476ebca579cbfd48d31bd90fa28fa257b209df585dcf62a0/cryptography-41.0.7-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; sys_platform == 'linux'

--- a/resources/python/requirements/3.7/requirements.txt
+++ b/resources/python/requirements/3.7/requirements.txt
@@ -9,9 +9,9 @@ service_identity==21.1.0
 # modules and rebuild the binaries
 attrs==22.2.0
 cffi==1.15.1
+cryptography==41.0.7 # Only for SAST. Should be also updated in resources/python/update_requirements.py
 hyperlink==21.0.0
 idna==3.4
 six==1.16.0
 zope.interface==5.5.2
 setuptools==65.5.1  # CVE-2022-40897
-cryptography==41.0.7 # Only for SAST. Should be also updated in resources/python/update_requirements.py

--- a/resources/python/requirements/3.9/requirements.txt
+++ b/resources/python/requirements/3.9/requirements.txt
@@ -15,7 +15,5 @@ six==1.16.0
 zope.interface==5.5.2
 setuptools==65.5.1  # CVE-2022-40897
 
-# Cryptography is a special use case for linux.
-# Default wheels requires GLIBC 2.28 (manylinux_2_28_x86_64) which is not available on CentOS 7.
-cryptography==41.0.7 ; sys_platform != 'linux'
-https://files.pythonhosted.org/packages/14/fd/dd5bd6ab0d12476ebca579cbfd48d31bd90fa28fa257b209df585dcf62a0/cryptography-41.0.7-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; sys_platform == 'linux'
+# We also should have here: cryptography==41.0.7
+# However, for special reasons, see resources/python/update_requirements.py

--- a/resources/python/requirements/3.9/requirements.txt
+++ b/resources/python/requirements/3.9/requirements.txt
@@ -9,9 +9,9 @@ service-identity==21.1.0
 # modules and rebuild the binaries
 attrs==22.2.0
 cffi==1.15.1
+cryptography==41.0.7 # Only for SAST. Should be also updated in resources/python/update_requirements.py
 hyperlink==21.0.0
 idna==3.4
 six==1.16.0
 zope.interface==5.5.2
 setuptools==65.5.1  # CVE-2022-40897
-cryptography==41.0.7 # Only for SAST. Should be also updated in resources/python/update_requirements.py

--- a/resources/python/requirements/3.9/requirements.txt
+++ b/resources/python/requirements/3.9/requirements.txt
@@ -14,6 +14,4 @@ idna==3.4
 six==1.16.0
 zope.interface==5.5.2
 setuptools==65.5.1  # CVE-2022-40897
-
-# We also should have here: cryptography==41.0.7
-# However, for special reasons, see resources/python/update_requirements.py
+cryptography==41.0.7 # Only for SAST. Should be also updated in resources/python/update_requirements.py

--- a/resources/python/requirements/3.9/requirements.txt
+++ b/resources/python/requirements/3.9/requirements.txt
@@ -9,10 +9,13 @@ service-identity==21.1.0
 # modules and rebuild the binaries
 attrs==22.2.0
 cffi==1.15.1
-cryptography==41.0.7 ; sys_platform != 'linux'
-https://files.pythonhosted.org/packages/14/fd/dd5bd6ab0d12476ebca579cbfd48d31bd90fa28fa257b209df585dcf62a0/cryptography-41.0.7-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; sys_platform == 'linux'
 hyperlink==21.0.0
 idna==3.4
 six==1.16.0
 zope.interface==5.5.2
 setuptools==65.5.1  # CVE-2022-40897
+
+# Cryptography is a special use case for linux.
+# Default wheels requires GLIBC 2.28 (manylinux_2_28_x86_64) which is not available on CentOS 7.
+cryptography==41.0.7 ; sys_platform != 'linux'
+https://files.pythonhosted.org/packages/14/fd/dd5bd6ab0d12476ebca579cbfd48d31bd90fa28fa257b209df585dcf62a0/cryptography-41.0.7-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; sys_platform == 'linux'

--- a/resources/python/requirements/3.9/requirements.txt
+++ b/resources/python/requirements/3.9/requirements.txt
@@ -9,7 +9,8 @@ service-identity==21.1.0
 # modules and rebuild the binaries
 attrs==22.2.0
 cffi==1.15.1
-cryptography==41.0.7
+cryptography==41.0.7 ; sys_platform != 'linux'
+https://files.pythonhosted.org/packages/14/fd/dd5bd6ab0d12476ebca579cbfd48d31bd90fa28fa257b209df585dcf62a0/cryptography-41.0.7-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; sys_platform == 'linux'
 hyperlink==21.0.0
 idna==3.4
 six==1.16.0

--- a/resources/python/update_requirements.py
+++ b/resources/python/update_requirements.py
@@ -217,20 +217,19 @@ class Updater(object):
             for dependency in dependencies:
                 package_name = dependency.split("==")[0]
 
+                # Cryptography is a special use case for Linux.
+                # Prioritized wheels require GLIBC 2.28 (manylinux_2_28_x86_64) which is not available on CentOS 7.
+                # Then, we download manylinux_2_17_x86_64 from PyPI.
+                if package_name == "cryptography":
+                    dependency = "cryptography==41.0.7 ; sys_platform != 'linux'\n"
+                    dependency += "https://files.pythonhosted.org/packages/14/fd/dd5bd6ab0d12476ebca579cbfd48d31bd90fa28fa257b209df585dcf62a0/cryptography-41.0.7-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; sys_platform == 'linux'"
+
+
                 # Figure which type of dependency it is and write
                 # it to the right requirements file.
                 requirement_to_add = [dependency + "\n"]
                 if package_name in self._binary_distributions:
-                    if package_name == "cryptography":
-                        # Cryptography is a special use case for linux.
-                        # Default wheels requires GLIBC 2.28 (manylinux_2_28_x86_64) which is not available on CentOS 7.
-                        cryptography_to_add = [
-                             "cryptography==41.0.7 ; sys_platform != 'linux'\n",
-                             "https://files.pythonhosted.org/packages/14/fd/dd5bd6ab0d12476ebca579cbfd48d31bd90fa28fa257b209df585dcf62a0/cryptography-41.0.7-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; sys_platform == 'linux'\n"
-                        ]
-                        bin_handler.writelines(cryptography_to_add)
-                    else:
-                        bin_handler.writelines(requirement_to_add)
+                    bin_handler.writelines(requirement_to_add)
                 else:
                     source_handler.writelines(requirement_to_add)
 

--- a/resources/python/update_requirements.py
+++ b/resources/python/update_requirements.py
@@ -221,7 +221,16 @@ class Updater(object):
                 # it to the right requirements file.
                 requirement_to_add = [dependency + "\n"]
                 if package_name in self._binary_distributions:
-                    bin_handler.writelines(requirement_to_add)
+                    if package_name == "cryptography":
+                        # Cryptography is a special use case for linux.
+                        # Default wheels requires GLIBC 2.28 (manylinux_2_28_x86_64) which is not available on CentOS 7.
+                        cryptography_to_add = [
+                             "cryptography==41.0.7 ; sys_platform != 'linux'\n",
+                             "https://files.pythonhosted.org/packages/14/fd/dd5bd6ab0d12476ebca579cbfd48d31bd90fa28fa257b209df585dcf62a0/cryptography-41.0.7-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; sys_platform == 'linux'\n"
+                        ]
+                        bin_handler.writelines(cryptography_to_add)
+                    else:
+                        bin_handler.writelines(requirement_to_add)
                 else:
                     source_handler.writelines(requirement_to_add)
 


### PR DESCRIPTION
tk-framework-desktopserver v1.6.2 updated [Cryptography 41.0.3](https://pypi.org/project/cryptography/#files) module which uses [cp37-abi3-manylinux_2_28_x86_64](https://github.com/shotgunsoftware/tk-framework-desktopserver/blob/v1.6.2/resources/python/bin/3.9/linux/cryptography-41.0.3.dist-info/WHEEL) WHEEL for both python 3.7 and 3.9 (this requires glibc 2.28 and breaks desktop menu items on CentOS7).

This PR attempts to fix this by explicitly installing a manylinux 2.17 compatible wheel on linux platforms.