### PR TITLE
SG-36027 Bundle modules for Python 3.11

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,14 +5,18 @@ ignore:
     - resources/python/bin/3.7/explicit_requirements.txt
     - resources/python/bin/3.9/explicit_requirements.txt
     - resources/python/bin/3.10/explicit_requirements.txt
+    - resources/python/bin/3.11/explicit_requirements.txt
     - resources/python/src/3.7/explicit_requirements.txt
     - resources/python/src/3.9/explicit_requirements.txt
     - resources/python/src/3.10/explicit_requirements.txt
+    - resources/python/src/3.11/explicit_requirements.txt
 exclude:
   global:
     - resources/python/bin/3.7/explicit_requirements.txt
     - resources/python/bin/3.9/explicit_requirements.txt
     - resources/python/bin/3.10/explicit_requirements.txt
+    - resources/python/bin/3.11/explicit_requirements.txt
     - resources/python/src/3.7/explicit_requirements.txt
     - resources/python/src/3.9/explicit_requirements.txt
     - resources/python/src/3.10/explicit_requirements.txt
+    - resources/python/src/3.11/explicit_requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![VFX Platform](https://img.shields.io/badge/vfxplatform-2024%20%7C%202023%20%7C%202022%20%7C%202021-blue.svg)](http://www.vfxplatform.com/)
-[![Python](https://img.shields.io/badge/python-3.10%20%7C%203.9%20%7C%203.7-blue.svg)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/python-3.11%20%7C%203.10%20%7C%203.9%20%7C%203.7-blue.svg)](https://www.python.org/)
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/shotgunsoftware.tk-framework-desktopserver?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=81&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Linting](https://img.shields.io/badge/PEP8%20by-Hound%20CI-a873d1.svg)](https://houndci.com)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,33 +29,33 @@ variables:
 
 # Launch into the build pipeline.
 jobs:
-# - template: build-pipeline.yml@templates
-#   parameters:
-#     additional_repositories:
-#       - name: tk-framework-desktopclient
-#       - name: tk-shotgun
-#     extra_test_dependencies:
-#       # Required when binary dependencies are not bundled
-#       - attrs==22.2.0    # Fix version. Otherwise tk-ci-tools will install latest
-#       - Twisted==22.10.0 # We use 22.10.0 to avoid breaking CI for Python 3.7
-#       - certifi==2024.7.4
-#       - autobahn==22.12.1
-#       - pyOpenSSL==24.0.0
-#       - service-identity==21.1.0
-#     post_tests_steps:
-#       - bash: python -m pytest tests/integration_tests/interpreters.py -v
-#         displayName: Run interpreter integration tests
-#         env:
-#           CI: 1  # Used to skip certain tests on Azure
-#           SHOTGUN_HOST: $(sg.ci.host)
-#           SHOTGUN_SCRIPT_NAME: $(sg.ci.script.name)
-#           SHOTGUN_SCRIPT_KEY: $(sg.ci.script.key)
-#           TK_TOOLCHAIN_HOST: $(sg.ci.host)
-#           TK_TOOLCHAIN_USER_LOGIN: $(sg.ci.human.login)
-#           TK_TOOLCHAIN_USER_PASSWORD: $(sg.ci.human.password)
-#           # Sandbox each test executing based on the Azure agent name. Those are
-#           # Azure Pipelines 1-10
-#           SHOTGUN_TEST_ENTITY_SUFFIX: '$(Agent.Name)'
+- template: build-pipeline.yml@templates
+  parameters:
+    additional_repositories:
+      - name: tk-framework-desktopclient
+      - name: tk-shotgun
+    extra_test_dependencies:
+      # Required when binary dependencies are not bundled
+      - attrs==22.2.0    # Fix version. Otherwise tk-ci-tools will install latest
+      - Twisted==22.10.0 # We use 22.10.0 to avoid breaking CI for Python 3.7
+      - certifi==2024.7.4
+      - autobahn==22.12.1
+      - pyOpenSSL==24.0.0
+      - service-identity==21.1.0
+    post_tests_steps:
+      - bash: python -m pytest tests/integration_tests/interpreters.py -v
+        displayName: Run interpreter integration tests
+        env:
+          CI: 1  # Used to skip certain tests on Azure
+          SHOTGUN_HOST: $(sg.ci.host)
+          SHOTGUN_SCRIPT_NAME: $(sg.ci.script.name)
+          SHOTGUN_SCRIPT_KEY: $(sg.ci.script.key)
+          TK_TOOLCHAIN_HOST: $(sg.ci.host)
+          TK_TOOLCHAIN_USER_LOGIN: $(sg.ci.human.login)
+          TK_TOOLCHAIN_USER_PASSWORD: $(sg.ci.human.password)
+          # Sandbox each test executing based on the Azure agent name. Those are
+          # Azure Pipelines 1-10
+          SHOTGUN_TEST_ENTITY_SUFFIX: '$(Agent.Name)'
 
 - template: resources/python/pipelines/pipelines.yml
   parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,33 +29,33 @@ variables:
 
 # Launch into the build pipeline.
 jobs:
-- template: build-pipeline.yml@templates
-  parameters:
-    additional_repositories:
-      - name: tk-framework-desktopclient
-      - name: tk-shotgun
-    extra_test_dependencies:
-      # Required when binary dependencies are not bundled
-      - attrs==22.2.0    # Fix version. Otherwise tk-ci-tools will install latest
-      - Twisted==22.10.0 # We use 22.10.0 to avoid breaking CI for Python 3.7
-      - certifi==2024.7.4
-      - autobahn==22.12.1
-      - pyOpenSSL==24.0.0
-      - service-identity==21.1.0
-    post_tests_steps:
-      - bash: python -m pytest tests/integration_tests/interpreters.py -v
-        displayName: Run interpreter integration tests
-        env:
-          CI: 1  # Used to skip certain tests on Azure
-          SHOTGUN_HOST: $(sg.ci.host)
-          SHOTGUN_SCRIPT_NAME: $(sg.ci.script.name)
-          SHOTGUN_SCRIPT_KEY: $(sg.ci.script.key)
-          TK_TOOLCHAIN_HOST: $(sg.ci.host)
-          TK_TOOLCHAIN_USER_LOGIN: $(sg.ci.human.login)
-          TK_TOOLCHAIN_USER_PASSWORD: $(sg.ci.human.password)
-          # Sandbox each test executing based on the Azure agent name. Those are
-          # Azure Pipelines 1-10
-          SHOTGUN_TEST_ENTITY_SUFFIX: '$(Agent.Name)'
+# - template: build-pipeline.yml@templates
+#   parameters:
+#     additional_repositories:
+#       - name: tk-framework-desktopclient
+#       - name: tk-shotgun
+#     extra_test_dependencies:
+#       # Required when binary dependencies are not bundled
+#       - attrs==22.2.0    # Fix version. Otherwise tk-ci-tools will install latest
+#       - Twisted==22.10.0 # We use 22.10.0 to avoid breaking CI for Python 3.7
+#       - certifi==2024.7.4
+#       - autobahn==22.12.1
+#       - pyOpenSSL==24.0.0
+#       - service-identity==21.1.0
+#     post_tests_steps:
+#       - bash: python -m pytest tests/integration_tests/interpreters.py -v
+#         displayName: Run interpreter integration tests
+#         env:
+#           CI: 1  # Used to skip certain tests on Azure
+#           SHOTGUN_HOST: $(sg.ci.host)
+#           SHOTGUN_SCRIPT_NAME: $(sg.ci.script.name)
+#           SHOTGUN_SCRIPT_KEY: $(sg.ci.script.key)
+#           TK_TOOLCHAIN_HOST: $(sg.ci.host)
+#           TK_TOOLCHAIN_USER_LOGIN: $(sg.ci.human.login)
+#           TK_TOOLCHAIN_USER_PASSWORD: $(sg.ci.human.password)
+#           # Sandbox each test executing based on the Azure agent name. Those are
+#           # Azure Pipelines 1-10
+#           SHOTGUN_TEST_ENTITY_SUFFIX: '$(Agent.Name)'
 
 - template: resources/python/pipelines/pipelines.yml
   parameters:

--- a/python/tk_framework_desktopserver/__init__.py
+++ b/python/tk_framework_desktopserver/__init__.py
@@ -25,6 +25,7 @@ binaries_path = os.path.join(python_path, "bin")
 _py_version = sys.version_info
 _version_dir = "{}.{}".format(_py_version.major, _py_version.minor)
 
+binaries_os_path = None
 if sgtk.util.is_macos():
     binaries_os_path = os.path.join(binaries_path, _version_dir, "mac")
 elif sgtk.util.is_windows():
@@ -35,14 +36,14 @@ elif sgtk.util.is_linux():
 if os.path.exists(binaries_os_path):
     sys.path.insert(0, binaries_os_path)
 else:
-    print(f"No binaries found for Python at {binaries_os_path}")
+    raise RuntimeError(f"No binaries found for Python at {binaries_os_path}")
 
 src_os_path = os.path.join(python_path, "src", _version_dir)
 
 if os.path.exists(src_os_path):
     sys.path.insert(0, src_os_path)
 else:
-    print(f"No sources found for Python at {src_os_path}")
+    raise RuntimeError(f"No sources found for Python at {src_os_path}")
 
 
 from .server import Server

--- a/python/tk_framework_desktopserver/__init__.py
+++ b/python/tk_framework_desktopserver/__init__.py
@@ -11,11 +11,8 @@
 import os
 import sys
 
-from .logger import get_logger
-
 import sgtk.util
 
-logger = get_logger(__name__)
 
 # framework path
 base_path = os.path.dirname(
@@ -38,14 +35,14 @@ elif sgtk.util.is_linux():
 if os.path.exists(binaries_os_path):
     sys.path.insert(0, binaries_os_path)
 else:
-    logger.error(f"No binaries found for Python at {binaries_os_path}")
+    print(f"No binaries found for Python at {binaries_os_path}")
 
 src_os_path = os.path.join(python_path, "src", _version_dir)
 
 if os.path.exists(src_os_path):
     sys.path.insert(0, src_os_path)
 else:
-    logger.error(f"No sources found for Python at {src_os_path}")
+    print(f"No sources found for Python at {src_os_path}")
 
 
 from .server import Server
@@ -53,6 +50,7 @@ from .server import ServerProtocol
 from .settings import Settings
 from .process_manager import ProcessManager
 from .certificates import get_certificate_handler
+from .logger import get_logger
 from .shotgun import get_shotgun_api
 from .errors import (
     MissingCertificateError,

--- a/python/tk_framework_desktopserver/__init__.py
+++ b/python/tk_framework_desktopserver/__init__.py
@@ -11,7 +11,11 @@
 import os
 import sys
 
+from .logger import get_logger
+
 import sgtk.util
+
+logger = get_logger(__name__)
 
 # framework path
 base_path = os.path.dirname(
@@ -25,20 +29,30 @@ _py_version = sys.version_info
 _version_dir = "{}.{}".format(_py_version.major, _py_version.minor)
 
 if sgtk.util.is_macos():
-    sys.path.insert(0, os.path.join(binaries_path, _version_dir, "mac"))
+    binaries_os_path = os.path.join(binaries_path, _version_dir, "mac")
 elif sgtk.util.is_windows():
-    sys.path.insert(0, os.path.join(binaries_path, _version_dir, "win"))
+    binaries_os_path = os.path.join(binaries_path, _version_dir, "win")
 elif sgtk.util.is_linux():
-    sys.path.insert(0, os.path.join(binaries_path, _version_dir, "linux"))
+    binaries_os_path = os.path.join(binaries_path, _version_dir, "linux")
 
-sys.path.insert(0, os.path.join(python_path, "src", _version_dir))
+if os.path.exists(binaries_os_path):
+    sys.path.insert(0, binaries_os_path)
+else:
+    logger.error(f"No binaries found for Python at {binaries_os_path}")
+
+src_os_path = os.path.join(python_path, "src", _version_dir)
+
+if os.path.exists(src_os_path):
+    sys.path.insert(0, src_os_path)
+else:
+    logger.error(f"No sources found for Python at {src_os_path}")
+
 
 from .server import Server
 from .server import ServerProtocol
 from .settings import Settings
 from .process_manager import ProcessManager
 from .certificates import get_certificate_handler
-from .logger import get_logger
 from .shotgun import get_shotgun_api
 from .errors import (
     MissingCertificateError,

--- a/resources/python/README.md
+++ b/resources/python/README.md
@@ -9,14 +9,17 @@ Officially Supported Python Versions:
   - 3.7.16
   - 3.9.16
   - 3.10.13
+  - 3.11.9
 - Windows 
   - 3.7.9
   - 3.9.13
   - 3.10.11
+  - 3.11.9
 - Linux: 
   - 3.7.16
   - 3.9.16
   - 3.10.13
+  - 3.11.9
 
 ## CI Automation
 

--- a/resources/python/pipelines/pipelines.yml
+++ b/resources/python/pipelines/pipelines.yml
@@ -103,238 +103,238 @@ jobs:
 # ---------------------------------------------
 # Binary dependencies run also in order to prevent git race conditions
 
-# - job: install_binary_dependencies_mac_3_7
-#   displayName: Install binary dependencies Mac 3.7
-#   dependsOn: install_source_dependencies_3_10
-#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-#   pool:
-#     vmImage: 'macOS-12'
-#   steps:
-#   - template: template.yml
-#     parameters:
-#       python_version: 3.7
-#   - script: |
-#       git checkout ${{ parameters.branch }}
-#       ./install_binary_mac.sh
-#       git commit -am "Update binary requirements in Mac Python 3.7"
-#       git push origin ${{ parameters.branch }}
-#     displayName: Update binary requirements
-#     workingDirectory: resources/python
+- job: install_binary_dependencies_mac_3_7
+  displayName: Install binary dependencies Mac 3.7
+  dependsOn: install_source_dependencies_3_10
+  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+  pool:
+    vmImage: 'macOS-12'
+  steps:
+  - template: template.yml
+    parameters:
+      python_version: 3.7
+  - script: |
+      git checkout ${{ parameters.branch }}
+      ./install_binary_mac.sh
+      git commit -am "Update binary requirements in Mac Python 3.7"
+      git push origin ${{ parameters.branch }}
+    displayName: Update binary requirements
+    workingDirectory: resources/python
 
-# - job: install_binary_dependencies_mac_3_9
-#   displayName: Install binary dependencies Mac 3.9
-#   dependsOn: install_binary_dependencies_mac_3_7
-#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-#   pool:
-#     vmImage: 'macOS-12'
-#   steps:
-#   - template: template.yml
-#     parameters:
-#       python_version: 3.9
-#   - script: |
-#       git checkout ${{ parameters.branch }}
-#       ./install_binary_mac.sh
-#       git commit -am "Update binary requirements in Mac Python 3.9"
-#       git push origin ${{ parameters.branch }}
-#     displayName: Update binary requirements
-#     workingDirectory: resources/python
+- job: install_binary_dependencies_mac_3_9
+  displayName: Install binary dependencies Mac 3.9
+  dependsOn: install_binary_dependencies_mac_3_7
+  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+  pool:
+    vmImage: 'macOS-12'
+  steps:
+  - template: template.yml
+    parameters:
+      python_version: 3.9
+  - script: |
+      git checkout ${{ parameters.branch }}
+      ./install_binary_mac.sh
+      git commit -am "Update binary requirements in Mac Python 3.9"
+      git push origin ${{ parameters.branch }}
+    displayName: Update binary requirements
+    workingDirectory: resources/python
 
-# - job: install_binary_dependencies_mac_3_10
-#   displayName: Install binary dependencies Mac 3.10
-#   dependsOn: install_binary_dependencies_mac_3_9
-#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-#   pool:
-#     vmImage: 'macOS-12'
-#   steps:
-#   - template: template.yml
-#     parameters:
-#       python_version: 3.10
-#   - script: |
-#       git checkout ${{ parameters.branch }}
-#       ./install_binary_mac.sh
-#       git commit -am "Update binary requirements in Mac Python 3.10"
-#       git push origin ${{ parameters.branch }}
-#     displayName: Update binary requirements
-#     workingDirectory: resources/python
+- job: install_binary_dependencies_mac_3_10
+  displayName: Install binary dependencies Mac 3.10
+  dependsOn: install_binary_dependencies_mac_3_9
+  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+  pool:
+    vmImage: 'macOS-12'
+  steps:
+  - template: template.yml
+    parameters:
+      python_version: 3.10
+  - script: |
+      git checkout ${{ parameters.branch }}
+      ./install_binary_mac.sh
+      git commit -am "Update binary requirements in Mac Python 3.10"
+      git push origin ${{ parameters.branch }}
+    displayName: Update binary requirements
+    workingDirectory: resources/python
 
-# - job: install_binary_dependencies_mac_3_11
-#   displayName: Install binary dependencies Mac 3.11
-#   dependsOn: install_binary_dependencies_mac_3_10
-#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-#   pool:
-#     vmImage: 'macOS-12'
-#   steps:
-#   - template: template.yml
-#     parameters:
-#       python_version: 3.11
-#   - script: |
-#       git checkout ${{ parameters.branch }}
-#       ./install_binary_mac.sh
-#       git commit -am "Update binary requirements in Mac Python 3.11"
-#       git push origin ${{ parameters.branch }}
-#     displayName: Update binary requirements
-#     workingDirectory: resources/python
+- job: install_binary_dependencies_mac_3_11
+  displayName: Install binary dependencies Mac 3.11
+  dependsOn: install_binary_dependencies_mac_3_10
+  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+  pool:
+    vmImage: 'macOS-12'
+  steps:
+  - template: template.yml
+    parameters:
+      python_version: 3.11
+  - script: |
+      git checkout ${{ parameters.branch }}
+      ./install_binary_mac.sh
+      git commit -am "Update binary requirements in Mac Python 3.11"
+      git push origin ${{ parameters.branch }}
+    displayName: Update binary requirements
+    workingDirectory: resources/python
 
-# - job: install_binary_dependencies_linux_3_7
-#   displayName: Install binary dependencies Linux 3.7
-#   dependsOn: install_binary_dependencies_mac_3_10
-#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-#   pool:
-#     vmImage: 'ubuntu-20.04'
-#   steps:
-#   - template: template.yml
-#     parameters:
-#       python_version: 3.7
-#   - script: |
-#       git checkout ${{ parameters.branch }}
-#       ./install_binary_linux.sh
-#       git commit -am "Update binary requirements in Linux Python 3.7"
-#       git push origin ${{ parameters.branch }}
-#     displayName: Update binary requirements
-#     workingDirectory: resources/python
+- job: install_binary_dependencies_linux_3_7
+  displayName: Install binary dependencies Linux 3.7
+  dependsOn: install_binary_dependencies_mac_3_10
+  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+  pool:
+    vmImage: 'ubuntu-20.04'
+  steps:
+  - template: template.yml
+    parameters:
+      python_version: 3.7
+  - script: |
+      git checkout ${{ parameters.branch }}
+      ./install_binary_linux.sh
+      git commit -am "Update binary requirements in Linux Python 3.7"
+      git push origin ${{ parameters.branch }}
+    displayName: Update binary requirements
+    workingDirectory: resources/python
 
-# - job: install_binary_dependencies_linux_3_9
-#   displayName: Install binary dependencies Linux 3.9
-#   dependsOn: install_binary_dependencies_linux_3_7
-#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-#   pool:
-#     vmImage: 'ubuntu-20.04'
-#   steps:
-#   - template: template.yml
-#     parameters:
-#       python_version: 3.9
-#   - script: |
-#       git checkout ${{ parameters.branch }}
-#       ./install_binary_linux.sh
-#       git commit -am "Update binary requirements in Linux Python 3.9"
-#       git push origin ${{ parameters.branch }}
-#     displayName: Update binary requirements
-#     workingDirectory: resources/python
+- job: install_binary_dependencies_linux_3_9
+  displayName: Install binary dependencies Linux 3.9
+  dependsOn: install_binary_dependencies_linux_3_7
+  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+  pool:
+    vmImage: 'ubuntu-20.04'
+  steps:
+  - template: template.yml
+    parameters:
+      python_version: 3.9
+  - script: |
+      git checkout ${{ parameters.branch }}
+      ./install_binary_linux.sh
+      git commit -am "Update binary requirements in Linux Python 3.9"
+      git push origin ${{ parameters.branch }}
+    displayName: Update binary requirements
+    workingDirectory: resources/python
 
-# - job: install_binary_dependencies_linux_3_10
-#   displayName: Install binary dependencies Linux 3.10
-#   dependsOn: install_binary_dependencies_linux_3_9
-#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-#   pool:
-#     vmImage: 'ubuntu-20.04'
-#   steps:
-#   - template: template.yml
-#     parameters:
-#       python_version: 3.10
-#   - script: |
-#       git checkout ${{ parameters.branch }}
-#       ./install_binary_linux.sh
-#       git commit -am "Update binary requirements in Linux Python 3.10"
-#       git push origin ${{ parameters.branch }}
-#     displayName: Update binary requirements
-#     workingDirectory: resources/python
+- job: install_binary_dependencies_linux_3_10
+  displayName: Install binary dependencies Linux 3.10
+  dependsOn: install_binary_dependencies_linux_3_9
+  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+  pool:
+    vmImage: 'ubuntu-20.04'
+  steps:
+  - template: template.yml
+    parameters:
+      python_version: 3.10
+  - script: |
+      git checkout ${{ parameters.branch }}
+      ./install_binary_linux.sh
+      git commit -am "Update binary requirements in Linux Python 3.10"
+      git push origin ${{ parameters.branch }}
+    displayName: Update binary requirements
+    workingDirectory: resources/python
 
-# - job: install_binary_dependencies_linux_3_11
-#   displayName: Install binary dependencies Linux 3.11
-#   dependsOn: install_binary_dependencies_linux_3_10
-#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-#   pool:
-#     vmImage: 'ubuntu-20.04'
-#   steps:
-#   - template: template.yml
-#     parameters:
-#       python_version: 3.11
-#   - script: |
-#       git checkout ${{ parameters.branch }}
-#       ./install_binary_linux.sh
-#       git commit -am "Update binary requirements in Linux Python 3.11"
-#       git push origin ${{ parameters.branch }}
-#     displayName: Update binary requirements
-#     workingDirectory: resources/python
+- job: install_binary_dependencies_linux_3_11
+  displayName: Install binary dependencies Linux 3.11
+  dependsOn: install_binary_dependencies_linux_3_10
+  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+  pool:
+    vmImage: 'ubuntu-20.04'
+  steps:
+  - template: template.yml
+    parameters:
+      python_version: 3.11
+  - script: |
+      git checkout ${{ parameters.branch }}
+      ./install_binary_linux.sh
+      git commit -am "Update binary requirements in Linux Python 3.11"
+      git push origin ${{ parameters.branch }}
+    displayName: Update binary requirements
+    workingDirectory: resources/python
 
-# - job: install_binary_dependencies_windows_3_7
-#   displayName: Install binary dependencies Windows 3.7
-#   dependsOn: install_binary_dependencies_linux_3_10
-#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-#   pool:
-#     vmImage: 'windows-2022'
-#   steps:
-#   - template: template.yml
-#     parameters:
-#       python_version: 3.7
-#   - script: |
-#       git checkout ${{ parameters.branch }}
-#     displayName: Update binary requirements
-#     workingDirectory: resources/python
-#   - powershell: .\install_binary_windows.ps1
-#     displayName: Run PowerShell Scripts
-#     workingDirectory: resources/python
-#   - script: |
-#       git commit -am "Update binary requirements in Windows Python 3.7"
-#       git push origin ${{ parameters.branch }}
-#     displayName: Run Push Scripts
-#     workingDirectory: resources/python
+- job: install_binary_dependencies_windows_3_7
+  displayName: Install binary dependencies Windows 3.7
+  dependsOn: install_binary_dependencies_linux_3_10
+  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+  pool:
+    vmImage: 'windows-2022'
+  steps:
+  - template: template.yml
+    parameters:
+      python_version: 3.7
+  - script: |
+      git checkout ${{ parameters.branch }}
+    displayName: Update binary requirements
+    workingDirectory: resources/python
+  - powershell: .\install_binary_windows.ps1
+    displayName: Run PowerShell Scripts
+    workingDirectory: resources/python
+  - script: |
+      git commit -am "Update binary requirements in Windows Python 3.7"
+      git push origin ${{ parameters.branch }}
+    displayName: Run Push Scripts
+    workingDirectory: resources/python
 
-# - job: install_binary_dependencies_windows_3_9
-#   displayName: Install binary dependencies Windows 3.9
-#   dependsOn: install_binary_dependencies_windows_3_7
-#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-#   pool:
-#     vmImage: 'windows-2022'
-#   steps:
-#   - template: template.yml
-#     parameters:
-#       python_version: 3.9
-#   - script: |
-#       git checkout ${{ parameters.branch }}
-#     displayName: Update binary requirements
-#     workingDirectory: resources/python
-#   - powershell: .\install_binary_windows.ps1
-#     displayName: Run PowerShell Scripts
-#     workingDirectory: resources/python
-#   - script: |
-#       git commit -am "Update binary requirements in Windows Python 3.9"
-#       git push origin ${{ parameters.branch }}
-#     displayName: Run Push Scripts
-#     workingDirectory: resources/python
+- job: install_binary_dependencies_windows_3_9
+  displayName: Install binary dependencies Windows 3.9
+  dependsOn: install_binary_dependencies_windows_3_7
+  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+  pool:
+    vmImage: 'windows-2022'
+  steps:
+  - template: template.yml
+    parameters:
+      python_version: 3.9
+  - script: |
+      git checkout ${{ parameters.branch }}
+    displayName: Update binary requirements
+    workingDirectory: resources/python
+  - powershell: .\install_binary_windows.ps1
+    displayName: Run PowerShell Scripts
+    workingDirectory: resources/python
+  - script: |
+      git commit -am "Update binary requirements in Windows Python 3.9"
+      git push origin ${{ parameters.branch }}
+    displayName: Run Push Scripts
+    workingDirectory: resources/python
 
-# - job: install_binary_dependencies_windows_3_10
-#   displayName: Install binary dependencies Windows 3.10
-#   dependsOn: install_binary_dependencies_windows_3_9
-#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-#   pool:
-#     vmImage: 'windows-2022'
-#   steps:
-#   - template: template.yml
-#     parameters:
-#       python_version: 3.10
-#   - script: |
-#       git checkout ${{ parameters.branch }}
-#     displayName: Update binary requirements
-#     workingDirectory: resources/python
-#   - powershell: .\install_binary_windows.ps1
-#     displayName: Run PowerShell Scripts
-#     workingDirectory: resources/python
-#   - script: |
-#       git commit -am "Update binary requirements in Windows Python 3.10"
-#       git push origin ${{ parameters.branch }}
-#     displayName: Run Push Scripts
-#     workingDirectory: resources/python
+- job: install_binary_dependencies_windows_3_10
+  displayName: Install binary dependencies Windows 3.10
+  dependsOn: install_binary_dependencies_windows_3_9
+  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+  pool:
+    vmImage: 'windows-2022'
+  steps:
+  - template: template.yml
+    parameters:
+      python_version: 3.10
+  - script: |
+      git checkout ${{ parameters.branch }}
+    displayName: Update binary requirements
+    workingDirectory: resources/python
+  - powershell: .\install_binary_windows.ps1
+    displayName: Run PowerShell Scripts
+    workingDirectory: resources/python
+  - script: |
+      git commit -am "Update binary requirements in Windows Python 3.10"
+      git push origin ${{ parameters.branch }}
+    displayName: Run Push Scripts
+    workingDirectory: resources/python
 
-# - job: install_binary_dependencies_windows_3_11
-#   displayName: Install binary dependencies Windows 3.11
-#   dependsOn: install_binary_dependencies_windows_3_10
-#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-#   pool:
-#     vmImage: 'windows-2022'
-#   steps:
-#   - template: template.yml
-#     parameters:
-#       python_version: 3.11
-#   - script: |
-#       git checkout ${{ parameters.branch }}
-#     displayName: Update binary requirements
-#     workingDirectory: resources/python
-#   - powershell: .\install_binary_windows.ps1
-#     displayName: Run PowerShell Scripts
-#     workingDirectory: resources/python
-#   - script: |
-#       git commit -am "Update binary requirements in Windows Python 3.11"
-#       git push origin ${{ parameters.branch }}
-#     displayName: Run Push Scripts
-#     workingDirectory: resources/python
+- job: install_binary_dependencies_windows_3_11
+  displayName: Install binary dependencies Windows 3.11
+  dependsOn: install_binary_dependencies_windows_3_10
+  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+  pool:
+    vmImage: 'windows-2022'
+  steps:
+  - template: template.yml
+    parameters:
+      python_version: 3.11
+  - script: |
+      git checkout ${{ parameters.branch }}
+    displayName: Update binary requirements
+    workingDirectory: resources/python
+  - powershell: .\install_binary_windows.ps1
+    displayName: Run PowerShell Scripts
+    workingDirectory: resources/python
+  - script: |
+      git commit -am "Update binary requirements in Windows Python 3.11"
+      git push origin ${{ parameters.branch }}
+    displayName: Run Push Scripts
+    workingDirectory: resources/python

--- a/resources/python/pipelines/pipelines.yml
+++ b/resources/python/pipelines/pipelines.yml
@@ -102,10 +102,11 @@ jobs:
 
 # ---------------------------------------------
 # Binary dependencies run also in order to prevent git race conditions
+# MacOS
 
 - job: install_binary_dependencies_mac_3_7
   displayName: Install binary dependencies Mac 3.7
-  dependsOn: install_source_dependencies_3_10
+  dependsOn: install_source_dependencies_3_11
   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
   pool:
     vmImage: 'macOS-12'
@@ -175,9 +176,11 @@ jobs:
     displayName: Update binary requirements
     workingDirectory: resources/python
 
+# Linux
+
 - job: install_binary_dependencies_linux_3_7
   displayName: Install binary dependencies Linux 3.7
-  dependsOn: install_binary_dependencies_mac_3_10
+  dependsOn: install_binary_dependencies_mac_3_11
   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
   pool:
     vmImage: 'ubuntu-20.04'
@@ -247,9 +250,11 @@ jobs:
     displayName: Update binary requirements
     workingDirectory: resources/python
 
+# Windows
+
 - job: install_binary_dependencies_windows_3_7
   displayName: Install binary dependencies Windows 3.7
-  dependsOn: install_binary_dependencies_linux_3_10
+  dependsOn: install_binary_dependencies_linux_3_11
   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
   pool:
     vmImage: 'windows-2022'

--- a/resources/python/pipelines/pipelines.yml
+++ b/resources/python/pipelines/pipelines.yml
@@ -53,7 +53,7 @@ jobs:
       ./install_source_only.sh
       git commit -am "Update source requirements 3.9"
       git push origin ${{ parameters.branch }}
-    displayName:Update source requirements 3.9
+    displayName: Update source requirements 3.9
     workingDirectory: resources/python
 
 - job: install_source_dependencies_3_10

--- a/resources/python/pipelines/pipelines.yml
+++ b/resources/python/pipelines/pipelines.yml
@@ -25,10 +25,13 @@ jobs:
   - script: |
       git checkout ${{ parameters.branch }}
       python update_requirements.py --clean-pip
+    displayName: Generate all explicit_requirements 3.7
+    workingDirectory: resources/python
+  - script: |
       ./install_source_only.sh
       git commit -am "Update source requirements 3.7"
       git push origin ${{ parameters.branch }}
-    displayName: Generate all explicit_requirements & Update source requirements 3.7
+    displayName: Update source requirements 3.7
     workingDirectory: resources/python
 
 - job: install_source_dependencies_3_9
@@ -44,10 +47,13 @@ jobs:
   - script: |
       git checkout ${{ parameters.branch }}
       python update_requirements.py --clean-pip
+    displayName: Generate all explicit_requirements 3.9
+    workingDirectory: resources/python
+  - script: |
       ./install_source_only.sh
       git commit -am "Update source requirements 3.9"
       git push origin ${{ parameters.branch }}
-    displayName: Generate all explicit_requirements & Update source requirements 3.9
+    displayName:Update source requirements 3.9
     workingDirectory: resources/python
 
 - job: install_source_dependencies_3_10
@@ -63,10 +69,13 @@ jobs:
   - script: |
       git checkout ${{ parameters.branch }}
       python update_requirements.py --clean-pip
+    displayName: Generate all explicit_requirements 3.10
+    workingDirectory: resources/python
+  - script: |
       ./install_source_only.sh
       git commit -am "Update source requirements 3.10"
       git push origin ${{ parameters.branch }}
-    displayName: Generate all explicit_requirements & Update source requirements 3.10
+    displayName: Update source requirements 3.10
     workingDirectory: resources/python
 
 - job: install_source_dependencies_3_11
@@ -82,10 +91,13 @@ jobs:
   - script: |
       git checkout ${{ parameters.branch }}
       python update_requirements.py --clean-pip
+    displayName: Generate all explicit_requirements 3.11
+    workingDirectory: resources/python
+  - script: |
       ./install_source_only.sh
       git commit -am "Update source requirements 3.11"
       git push origin ${{ parameters.branch }}
-    displayName: Generate all explicit_requirements & Update source requirements 3.11
+    displayName: Update source requirements 3.11
     workingDirectory: resources/python
 
 # ---------------------------------------------

--- a/resources/python/pipelines/pipelines.yml
+++ b/resources/python/pipelines/pipelines.yml
@@ -24,11 +24,11 @@ jobs:
     displayName: Create branch if not exists or update
   - script: |
       git checkout ${{ parameters.branch }}
-      python update_requirements.py
+      python update_requirements.py --clean-pip
       ./install_source_only.sh
       git commit -am "Update source requirements 3.7"
       git push origin ${{ parameters.branch }}
-    displayName: Generate all explicit_requirements & Update source requirements
+    displayName: Generate all explicit_requirements & Update source requirements 3.7
     workingDirectory: resources/python
 
 - job: install_source_dependencies_3_9
@@ -43,11 +43,11 @@ jobs:
       python_version: 3.9
   - script: |
       git checkout ${{ parameters.branch }}
-      python update_requirements.py
+      python update_requirements.py --clean-pip
       ./install_source_only.sh
       git commit -am "Update source requirements 3.9"
       git push origin ${{ parameters.branch }}
-    displayName: Generate all explicit_requirements & Update source requirements
+    displayName: Generate all explicit_requirements & Update source requirements 3.9
     workingDirectory: resources/python
 
 - job: install_source_dependencies_3_10
@@ -62,11 +62,11 @@ jobs:
       python_version: 3.10
   - script: |
       git checkout ${{ parameters.branch }}
-      python update_requirements.py
+      python update_requirements.py --clean-pip
       ./install_source_only.sh
       git commit -am "Update source requirements 3.10"
       git push origin ${{ parameters.branch }}
-    displayName: Generate all explicit_requirements & Update source requirements
+    displayName: Generate all explicit_requirements & Update source requirements 3.10
     workingDirectory: resources/python
 
 - job: install_source_dependencies_3_11
@@ -81,11 +81,11 @@ jobs:
       python_version: 3.11
   - script: |
       git checkout ${{ parameters.branch }}
-      python update_requirements.py
+      python update_requirements.py --clean-pip
       ./install_source_only.sh
       git commit -am "Update source requirements 3.11"
       git push origin ${{ parameters.branch }}
-    displayName: Generate all explicit_requirements & Update source requirements
+    displayName: Generate all explicit_requirements & Update source requirements 3.11
     workingDirectory: resources/python
 
 # ---------------------------------------------

--- a/resources/python/pipelines/pipelines.yml
+++ b/resources/python/pipelines/pipelines.yml
@@ -91,238 +91,238 @@ jobs:
 # ---------------------------------------------
 # Binary dependencies run also in order to prevent git race conditions
 
-- job: install_binary_dependencies_mac_3_7
-  displayName: Install binary dependencies Mac 3.7
-  dependsOn: install_source_dependencies_3_10
-  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-  pool:
-    vmImage: 'macOS-12'
-  steps:
-  - template: template.yml
-    parameters:
-      python_version: 3.7
-  - script: |
-      git checkout ${{ parameters.branch }}
-      ./install_binary_mac.sh
-      git commit -am "Update binary requirements in Mac Python 3.7"
-      git push origin ${{ parameters.branch }}
-    displayName: Update binary requirements
-    workingDirectory: resources/python
+# - job: install_binary_dependencies_mac_3_7
+#   displayName: Install binary dependencies Mac 3.7
+#   dependsOn: install_source_dependencies_3_10
+#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+#   pool:
+#     vmImage: 'macOS-12'
+#   steps:
+#   - template: template.yml
+#     parameters:
+#       python_version: 3.7
+#   - script: |
+#       git checkout ${{ parameters.branch }}
+#       ./install_binary_mac.sh
+#       git commit -am "Update binary requirements in Mac Python 3.7"
+#       git push origin ${{ parameters.branch }}
+#     displayName: Update binary requirements
+#     workingDirectory: resources/python
 
-- job: install_binary_dependencies_mac_3_9
-  displayName: Install binary dependencies Mac 3.9
-  dependsOn: install_binary_dependencies_mac_3_7
-  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-  pool:
-    vmImage: 'macOS-12'
-  steps:
-  - template: template.yml
-    parameters:
-      python_version: 3.9
-  - script: |
-      git checkout ${{ parameters.branch }}
-      ./install_binary_mac.sh
-      git commit -am "Update binary requirements in Mac Python 3.9"
-      git push origin ${{ parameters.branch }}
-    displayName: Update binary requirements
-    workingDirectory: resources/python
+# - job: install_binary_dependencies_mac_3_9
+#   displayName: Install binary dependencies Mac 3.9
+#   dependsOn: install_binary_dependencies_mac_3_7
+#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+#   pool:
+#     vmImage: 'macOS-12'
+#   steps:
+#   - template: template.yml
+#     parameters:
+#       python_version: 3.9
+#   - script: |
+#       git checkout ${{ parameters.branch }}
+#       ./install_binary_mac.sh
+#       git commit -am "Update binary requirements in Mac Python 3.9"
+#       git push origin ${{ parameters.branch }}
+#     displayName: Update binary requirements
+#     workingDirectory: resources/python
 
-- job: install_binary_dependencies_mac_3_10
-  displayName: Install binary dependencies Mac 3.10
-  dependsOn: install_binary_dependencies_mac_3_9
-  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-  pool:
-    vmImage: 'macOS-12'
-  steps:
-  - template: template.yml
-    parameters:
-      python_version: 3.10
-  - script: |
-      git checkout ${{ parameters.branch }}
-      ./install_binary_mac.sh
-      git commit -am "Update binary requirements in Mac Python 3.10"
-      git push origin ${{ parameters.branch }}
-    displayName: Update binary requirements
-    workingDirectory: resources/python
+# - job: install_binary_dependencies_mac_3_10
+#   displayName: Install binary dependencies Mac 3.10
+#   dependsOn: install_binary_dependencies_mac_3_9
+#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+#   pool:
+#     vmImage: 'macOS-12'
+#   steps:
+#   - template: template.yml
+#     parameters:
+#       python_version: 3.10
+#   - script: |
+#       git checkout ${{ parameters.branch }}
+#       ./install_binary_mac.sh
+#       git commit -am "Update binary requirements in Mac Python 3.10"
+#       git push origin ${{ parameters.branch }}
+#     displayName: Update binary requirements
+#     workingDirectory: resources/python
 
-- job: install_binary_dependencies_mac_3_11
-  displayName: Install binary dependencies Mac 3.11
-  dependsOn: install_binary_dependencies_mac_3_10
-  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-  pool:
-    vmImage: 'macOS-12'
-  steps:
-  - template: template.yml
-    parameters:
-      python_version: 3.11
-  - script: |
-      git checkout ${{ parameters.branch }}
-      ./install_binary_mac.sh
-      git commit -am "Update binary requirements in Mac Python 3.11"
-      git push origin ${{ parameters.branch }}
-    displayName: Update binary requirements
-    workingDirectory: resources/python
+# - job: install_binary_dependencies_mac_3_11
+#   displayName: Install binary dependencies Mac 3.11
+#   dependsOn: install_binary_dependencies_mac_3_10
+#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+#   pool:
+#     vmImage: 'macOS-12'
+#   steps:
+#   - template: template.yml
+#     parameters:
+#       python_version: 3.11
+#   - script: |
+#       git checkout ${{ parameters.branch }}
+#       ./install_binary_mac.sh
+#       git commit -am "Update binary requirements in Mac Python 3.11"
+#       git push origin ${{ parameters.branch }}
+#     displayName: Update binary requirements
+#     workingDirectory: resources/python
 
-- job: install_binary_dependencies_linux_3_7
-  displayName: Install binary dependencies Linux 3.7
-  dependsOn: install_binary_dependencies_mac_3_10
-  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-  pool:
-    vmImage: 'ubuntu-20.04'
-  steps:
-  - template: template.yml
-    parameters:
-      python_version: 3.7
-  - script: |
-      git checkout ${{ parameters.branch }}
-      ./install_binary_linux.sh
-      git commit -am "Update binary requirements in Linux Python 3.7"
-      git push origin ${{ parameters.branch }}
-    displayName: Update binary requirements
-    workingDirectory: resources/python
+# - job: install_binary_dependencies_linux_3_7
+#   displayName: Install binary dependencies Linux 3.7
+#   dependsOn: install_binary_dependencies_mac_3_10
+#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+#   pool:
+#     vmImage: 'ubuntu-20.04'
+#   steps:
+#   - template: template.yml
+#     parameters:
+#       python_version: 3.7
+#   - script: |
+#       git checkout ${{ parameters.branch }}
+#       ./install_binary_linux.sh
+#       git commit -am "Update binary requirements in Linux Python 3.7"
+#       git push origin ${{ parameters.branch }}
+#     displayName: Update binary requirements
+#     workingDirectory: resources/python
 
-- job: install_binary_dependencies_linux_3_9
-  displayName: Install binary dependencies Linux 3.9
-  dependsOn: install_binary_dependencies_linux_3_7
-  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-  pool:
-    vmImage: 'ubuntu-20.04'
-  steps:
-  - template: template.yml
-    parameters:
-      python_version: 3.9
-  - script: |
-      git checkout ${{ parameters.branch }}
-      ./install_binary_linux.sh
-      git commit -am "Update binary requirements in Linux Python 3.9"
-      git push origin ${{ parameters.branch }}
-    displayName: Update binary requirements
-    workingDirectory: resources/python
+# - job: install_binary_dependencies_linux_3_9
+#   displayName: Install binary dependencies Linux 3.9
+#   dependsOn: install_binary_dependencies_linux_3_7
+#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+#   pool:
+#     vmImage: 'ubuntu-20.04'
+#   steps:
+#   - template: template.yml
+#     parameters:
+#       python_version: 3.9
+#   - script: |
+#       git checkout ${{ parameters.branch }}
+#       ./install_binary_linux.sh
+#       git commit -am "Update binary requirements in Linux Python 3.9"
+#       git push origin ${{ parameters.branch }}
+#     displayName: Update binary requirements
+#     workingDirectory: resources/python
 
-- job: install_binary_dependencies_linux_3_10
-  displayName: Install binary dependencies Linux 3.10
-  dependsOn: install_binary_dependencies_linux_3_9
-  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-  pool:
-    vmImage: 'ubuntu-20.04'
-  steps:
-  - template: template.yml
-    parameters:
-      python_version: 3.10
-  - script: |
-      git checkout ${{ parameters.branch }}
-      ./install_binary_linux.sh
-      git commit -am "Update binary requirements in Linux Python 3.10"
-      git push origin ${{ parameters.branch }}
-    displayName: Update binary requirements
-    workingDirectory: resources/python
+# - job: install_binary_dependencies_linux_3_10
+#   displayName: Install binary dependencies Linux 3.10
+#   dependsOn: install_binary_dependencies_linux_3_9
+#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+#   pool:
+#     vmImage: 'ubuntu-20.04'
+#   steps:
+#   - template: template.yml
+#     parameters:
+#       python_version: 3.10
+#   - script: |
+#       git checkout ${{ parameters.branch }}
+#       ./install_binary_linux.sh
+#       git commit -am "Update binary requirements in Linux Python 3.10"
+#       git push origin ${{ parameters.branch }}
+#     displayName: Update binary requirements
+#     workingDirectory: resources/python
 
-- job: install_binary_dependencies_linux_3_11
-  displayName: Install binary dependencies Linux 3.11
-  dependsOn: install_binary_dependencies_linux_3_10
-  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-  pool:
-    vmImage: 'ubuntu-20.04'
-  steps:
-  - template: template.yml
-    parameters:
-      python_version: 3.11
-  - script: |
-      git checkout ${{ parameters.branch }}
-      ./install_binary_linux.sh
-      git commit -am "Update binary requirements in Linux Python 3.11"
-      git push origin ${{ parameters.branch }}
-    displayName: Update binary requirements
-    workingDirectory: resources/python
+# - job: install_binary_dependencies_linux_3_11
+#   displayName: Install binary dependencies Linux 3.11
+#   dependsOn: install_binary_dependencies_linux_3_10
+#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+#   pool:
+#     vmImage: 'ubuntu-20.04'
+#   steps:
+#   - template: template.yml
+#     parameters:
+#       python_version: 3.11
+#   - script: |
+#       git checkout ${{ parameters.branch }}
+#       ./install_binary_linux.sh
+#       git commit -am "Update binary requirements in Linux Python 3.11"
+#       git push origin ${{ parameters.branch }}
+#     displayName: Update binary requirements
+#     workingDirectory: resources/python
 
-- job: install_binary_dependencies_windows_3_7
-  displayName: Install binary dependencies Windows 3.7
-  dependsOn: install_binary_dependencies_linux_3_10
-  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-  pool:
-    vmImage: 'windows-2022'
-  steps:
-  - template: template.yml
-    parameters:
-      python_version: 3.7
-  - script: |
-      git checkout ${{ parameters.branch }}
-    displayName: Update binary requirements
-    workingDirectory: resources/python
-  - powershell: .\install_binary_windows.ps1
-    displayName: Run PowerShell Scripts
-    workingDirectory: resources/python
-  - script: |
-      git commit -am "Update binary requirements in Windows Python 3.7"
-      git push origin ${{ parameters.branch }}
-    displayName: Run Push Scripts
-    workingDirectory: resources/python
+# - job: install_binary_dependencies_windows_3_7
+#   displayName: Install binary dependencies Windows 3.7
+#   dependsOn: install_binary_dependencies_linux_3_10
+#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+#   pool:
+#     vmImage: 'windows-2022'
+#   steps:
+#   - template: template.yml
+#     parameters:
+#       python_version: 3.7
+#   - script: |
+#       git checkout ${{ parameters.branch }}
+#     displayName: Update binary requirements
+#     workingDirectory: resources/python
+#   - powershell: .\install_binary_windows.ps1
+#     displayName: Run PowerShell Scripts
+#     workingDirectory: resources/python
+#   - script: |
+#       git commit -am "Update binary requirements in Windows Python 3.7"
+#       git push origin ${{ parameters.branch }}
+#     displayName: Run Push Scripts
+#     workingDirectory: resources/python
 
-- job: install_binary_dependencies_windows_3_9
-  displayName: Install binary dependencies Windows 3.9
-  dependsOn: install_binary_dependencies_windows_3_7
-  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-  pool:
-    vmImage: 'windows-2022'
-  steps:
-  - template: template.yml
-    parameters:
-      python_version: 3.9
-  - script: |
-      git checkout ${{ parameters.branch }}
-    displayName: Update binary requirements
-    workingDirectory: resources/python
-  - powershell: .\install_binary_windows.ps1
-    displayName: Run PowerShell Scripts
-    workingDirectory: resources/python
-  - script: |
-      git commit -am "Update binary requirements in Windows Python 3.9"
-      git push origin ${{ parameters.branch }}
-    displayName: Run Push Scripts
-    workingDirectory: resources/python
+# - job: install_binary_dependencies_windows_3_9
+#   displayName: Install binary dependencies Windows 3.9
+#   dependsOn: install_binary_dependencies_windows_3_7
+#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+#   pool:
+#     vmImage: 'windows-2022'
+#   steps:
+#   - template: template.yml
+#     parameters:
+#       python_version: 3.9
+#   - script: |
+#       git checkout ${{ parameters.branch }}
+#     displayName: Update binary requirements
+#     workingDirectory: resources/python
+#   - powershell: .\install_binary_windows.ps1
+#     displayName: Run PowerShell Scripts
+#     workingDirectory: resources/python
+#   - script: |
+#       git commit -am "Update binary requirements in Windows Python 3.9"
+#       git push origin ${{ parameters.branch }}
+#     displayName: Run Push Scripts
+#     workingDirectory: resources/python
 
-- job: install_binary_dependencies_windows_3_10
-  displayName: Install binary dependencies Windows 3.10
-  dependsOn: install_binary_dependencies_windows_3_9
-  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-  pool:
-    vmImage: 'windows-2022'
-  steps:
-  - template: template.yml
-    parameters:
-      python_version: 3.10
-  - script: |
-      git checkout ${{ parameters.branch }}
-    displayName: Update binary requirements
-    workingDirectory: resources/python
-  - powershell: .\install_binary_windows.ps1
-    displayName: Run PowerShell Scripts
-    workingDirectory: resources/python
-  - script: |
-      git commit -am "Update binary requirements in Windows Python 3.10"
-      git push origin ${{ parameters.branch }}
-    displayName: Run Push Scripts
-    workingDirectory: resources/python
+# - job: install_binary_dependencies_windows_3_10
+#   displayName: Install binary dependencies Windows 3.10
+#   dependsOn: install_binary_dependencies_windows_3_9
+#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+#   pool:
+#     vmImage: 'windows-2022'
+#   steps:
+#   - template: template.yml
+#     parameters:
+#       python_version: 3.10
+#   - script: |
+#       git checkout ${{ parameters.branch }}
+#     displayName: Update binary requirements
+#     workingDirectory: resources/python
+#   - powershell: .\install_binary_windows.ps1
+#     displayName: Run PowerShell Scripts
+#     workingDirectory: resources/python
+#   - script: |
+#       git commit -am "Update binary requirements in Windows Python 3.10"
+#       git push origin ${{ parameters.branch }}
+#     displayName: Run Push Scripts
+#     workingDirectory: resources/python
 
-- job: install_binary_dependencies_windows_3_11
-  displayName: Install binary dependencies Windows 3.11
-  dependsOn: install_binary_dependencies_windows_3_10
-  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-  pool:
-    vmImage: 'windows-2022'
-  steps:
-  - template: template.yml
-    parameters:
-      python_version: 3.11
-  - script: |
-      git checkout ${{ parameters.branch }}
-    displayName: Update binary requirements
-    workingDirectory: resources/python
-  - powershell: .\install_binary_windows.ps1
-    displayName: Run PowerShell Scripts
-    workingDirectory: resources/python
-  - script: |
-      git commit -am "Update binary requirements in Windows Python 3.11"
-      git push origin ${{ parameters.branch }}
-    displayName: Run Push Scripts
-    workingDirectory: resources/python
+# - job: install_binary_dependencies_windows_3_11
+#   displayName: Install binary dependencies Windows 3.11
+#   dependsOn: install_binary_dependencies_windows_3_10
+#   condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+#   pool:
+#     vmImage: 'windows-2022'
+#   steps:
+#   - template: template.yml
+#     parameters:
+#       python_version: 3.11
+#   - script: |
+#       git checkout ${{ parameters.branch }}
+#     displayName: Update binary requirements
+#     workingDirectory: resources/python
+#   - powershell: .\install_binary_windows.ps1
+#     displayName: Run PowerShell Scripts
+#     workingDirectory: resources/python
+#   - script: |
+#       git commit -am "Update binary requirements in Windows Python 3.11"
+#       git push origin ${{ parameters.branch }}
+#     displayName: Run Push Scripts
+#     workingDirectory: resources/python

--- a/resources/python/pipelines/pipelines.yml
+++ b/resources/python/pipelines/pipelines.yml
@@ -69,6 +69,25 @@ jobs:
     displayName: Generate all explicit_requirements & Update source requirements
     workingDirectory: resources/python
 
+- job: install_source_dependencies_3_11
+  displayName: Install source dependencies Python 3.11
+  dependsOn: install_source_dependencies_3_10
+  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+  pool:
+    vmImage: 'macOS-12'
+  steps:
+  - template: template.yml
+    parameters:
+      python_version: 3.11
+  - script: |
+      git checkout ${{ parameters.branch }}
+      python update_requirements.py
+      ./install_source_only.sh
+      git commit -am "Update source requirements 3.11"
+      git push origin ${{ parameters.branch }}
+    displayName: Generate all explicit_requirements & Update source requirements
+    workingDirectory: resources/python
+
 # ---------------------------------------------
 # Binary dependencies run also in order to prevent git race conditions
 
@@ -126,6 +145,24 @@ jobs:
     displayName: Update binary requirements
     workingDirectory: resources/python
 
+- job: install_binary_dependencies_mac_3_11
+  displayName: Install binary dependencies Mac 3.11
+  dependsOn: install_binary_dependencies_mac_3_10
+  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+  pool:
+    vmImage: 'macOS-12'
+  steps:
+  - template: template.yml
+    parameters:
+      python_version: 3.11
+  - script: |
+      git checkout ${{ parameters.branch }}
+      ./install_binary_mac.sh
+      git commit -am "Update binary requirements in Mac Python 3.11"
+      git push origin ${{ parameters.branch }}
+    displayName: Update binary requirements
+    workingDirectory: resources/python
+
 - job: install_binary_dependencies_linux_3_7
   displayName: Install binary dependencies Linux 3.7
   dependsOn: install_binary_dependencies_mac_3_10
@@ -176,6 +213,24 @@ jobs:
       git checkout ${{ parameters.branch }}
       ./install_binary_linux.sh
       git commit -am "Update binary requirements in Linux Python 3.10"
+      git push origin ${{ parameters.branch }}
+    displayName: Update binary requirements
+    workingDirectory: resources/python
+
+- job: install_binary_dependencies_linux_3_11
+  displayName: Install binary dependencies Linux 3.11
+  dependsOn: install_binary_dependencies_linux_3_10
+  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+  pool:
+    vmImage: 'ubuntu-20.04'
+  steps:
+  - template: template.yml
+    parameters:
+      python_version: 3.11
+  - script: |
+      git checkout ${{ parameters.branch }}
+      ./install_binary_linux.sh
+      git commit -am "Update binary requirements in Linux Python 3.11"
       git push origin ${{ parameters.branch }}
     displayName: Update binary requirements
     workingDirectory: resources/python
@@ -245,6 +300,29 @@ jobs:
     workingDirectory: resources/python
   - script: |
       git commit -am "Update binary requirements in Windows Python 3.10"
+      git push origin ${{ parameters.branch }}
+    displayName: Run Push Scripts
+    workingDirectory: resources/python
+
+- job: install_binary_dependencies_windows_3_11
+  displayName: Install binary dependencies Windows 3.11
+  dependsOn: install_binary_dependencies_windows_3_10
+  condition: and(not(endsWith( variables['System.PullRequest.SourceBranch'], '-automated')), ne(variables['Build.SourceBranch'], 'refs/heads/master'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
+  pool:
+    vmImage: 'windows-2022'
+  steps:
+  - template: template.yml
+    parameters:
+      python_version: 3.11
+  - script: |
+      git checkout ${{ parameters.branch }}
+    displayName: Update binary requirements
+    workingDirectory: resources/python
+  - powershell: .\install_binary_windows.ps1
+    displayName: Run PowerShell Scripts
+    workingDirectory: resources/python
+  - script: |
+      git commit -am "Update binary requirements in Windows Python 3.11"
       git push origin ${{ parameters.branch }}
     displayName: Run Push Scripts
     workingDirectory: resources/python

--- a/resources/python/requirements/3.11/requirements.txt
+++ b/resources/python/requirements/3.11/requirements.txt
@@ -1,0 +1,17 @@
+Twisted==23.10.0
+certifi==2024.7.4
+autobahn==22.12.1
+pyOpenSSL==24.0.0
+service-identity==21.1.0
+
+# When updating certifi to match the version released with Desktop, some other unrelated modules (that are second
+# level dependencies) were updating. The list below pins these versions for now until the next time we need to update
+# modules and rebuild the binaries
+attrs==22.2.0
+cffi==1.15.1
+cryptography==42.0.4 # Only for SAST. Should be also updated in resources/python/update_requirements.py
+hyperlink==21.0.0
+idna==3.7
+six==1.16.0
+zope.interface==5.5.2
+setuptools==70.0.0  # CVE-2024-6345

--- a/resources/python/requirements/3.7/requirements.txt
+++ b/resources/python/requirements/3.7/requirements.txt
@@ -14,4 +14,4 @@ hyperlink==21.0.0
 idna==3.7
 six==1.16.0
 zope.interface==5.5.2
-setuptools==70.0.0  # CVE-2024-6345
+setuptools==68.0.0  # CVE-2024-6345

--- a/resources/python/update_requirements.py
+++ b/resources/python/update_requirements.py
@@ -91,6 +91,7 @@ class Updater(object):
         # No matter why we are leaving this method, we should be removing
         # what was installed.
         print("Cleaning PIP dependencies")
+        
         for dependency in self._pip_freeze():
             cmd = "uninstall -y {}".format(dependency)
             self._pip(cmd)
@@ -110,8 +111,9 @@ class Updater(object):
                     e.stderr.decode("utf-8"),
                 )
             )
-
-        return output.decode("utf-8")
+        
+        output = output.decode("utf-8")
+        return output
 
     @staticmethod
     def _git(cmd):

--- a/resources/python/update_requirements.py
+++ b/resources/python/update_requirements.py
@@ -100,6 +100,9 @@ class Updater(object):
         pip_cmd = "python -m pip".split() + cmd.split()
         try:
             output = subprocess.check_output(pip_cmd)
+
+            if self._is_python_3:
+                output = output.decode("utf-8")
         except subprocess.CalledProcessError:
             raise UpdateException(
                 "Error running pip command: {}\n{}".format(

--- a/resources/python/update_requirements.py
+++ b/resources/python/update_requirements.py
@@ -98,7 +98,15 @@ class Updater(object):
     def _pip(self, cmd):
         """Run the pip command."""
         pip_cmd = "python -m pip".split() + cmd.split()
-        output = subprocess.check_output(pip_cmd)
+        try:
+            output = subprocess.check_output(pip_cmd)
+        except subprocess.CalledProcessError as e:
+            raise UpdateException(
+                "Error running pip command: {}\n{}".format(
+                    " ".join(pip_cmd),
+                    e.output,
+                )
+            )
 
         if self._is_python_3:
             output = output.decode("utf-8")
@@ -159,9 +167,11 @@ class Updater(object):
             bin_dir,
             "explicit_requirements.txt"
         )
+        print(f"Writing files {source_reqs_path}, {bin_reqs_path}")
 
         for path in [source_dir, bin_dir]:
             if not os.path.isdir(path):
+                print(f"Creating directory {path}")
                 os.makedirs(path)
 
         with open(source_reqs_path, 'w') as source_handler, \

--- a/resources/python/update_requirements.py
+++ b/resources/python/update_requirements.py
@@ -78,79 +78,6 @@ class Updater(object):
             "bin",
         )
 
-        # paths for final requirements files
-        self._source_reqs_3_7_dir = os.path.join(
-            self._sources_dir,
-            "3.7",
-        )
-        self._source_reqs_3_7_path = os.path.join(
-            self._source_reqs_3_7_dir,
-            "explicit_requirements.txt"
-        )
-
-        self._source_reqs_3_9_dir = os.path.join(
-            self._sources_dir,
-            "3.9",
-        )
-        self._source_reqs_3_9_path = os.path.join(
-            self._source_reqs_3_9_dir,
-            "explicit_requirements.txt"
-        )
-
-        self._source_reqs_3_10_dir = os.path.join(
-            self._sources_dir,
-            "3.10",
-        )
-        self._source_reqs_3_10_path = os.path.join(
-            self._source_reqs_3_10_dir,
-            "explicit_requirements.txt"
-        )
-
-        self._source_reqs_3_11_dir = os.path.join(
-            self._sources_dir,
-            "3.11",
-        )
-        self._source_reqs_3_11_path = os.path.join(
-            self._source_reqs_3_11_dir,
-            "explicit_requirements.txt"
-        )
-
-        self._bin_reqs_3_7_dir = os.path.join(
-            self._bin_dir,
-            "3.7",
-        )
-        self._bin_reqs_3_7_path = os.path.join(
-            self._bin_reqs_3_7_dir,
-            "explicit_requirements.txt"
-        )
-
-        self._bin_reqs_3_9_dir = os.path.join(
-            self._bin_dir,
-            "3.9",
-        )
-        self._bin_reqs_3_9_path = os.path.join(
-            self._bin_reqs_3_9_dir,
-            "explicit_requirements.txt"
-        )
-
-        self._bin_reqs_3_10_dir = os.path.join(
-            self._bin_dir,
-            "3.10",
-        )
-        self._bin_reqs_3_10_path = os.path.join(
-            self._bin_reqs_3_10_dir,
-            "explicit_requirements.txt"
-        )
-
-        self._bin_reqs_3_11_dir = os.path.join(
-            self._bin_dir,
-            "3.11",
-        )
-        self._bin_reqs_3_11_path = os.path.join(
-            self._bin_reqs_3_11_dir,
-            "explicit_requirements.txt"
-        )
-
     def _pip_freeze(self):
         """List all packages installed."""
         output = self._pip("freeze").strip()
@@ -163,6 +90,7 @@ class Updater(object):
         """Uninstall all packages with pip."""
         # No matter why we are leaving this method, we should be removing
         # what was installed.
+        print("Cleaning PIP dependencies")
         for dependency in self._pip_freeze():
             cmd = "uninstall -y {}".format(dependency)
             self._pip(cmd)
@@ -215,12 +143,22 @@ class Updater(object):
         """
         Update the requirement files.
         """
-        version = self._python_version_underscore_format
-        source_dir = getattr(self, "_source_reqs_{}_dir".format(version))
-        source_reqs_path = getattr(self, "_source_reqs_{}_path".format(
-            version))
-        bin_dir = getattr(self, "_bin_reqs_{}_dir".format(version))
-        bin_reqs_path = getattr(self, "_bin_reqs_{}_path".format(version))
+        source_dir = os.path.join(
+            self._sources_dir,
+            self._python_version_dot_format,
+        )
+        source_reqs_path = os.path.join(
+            source_dir,
+            "explicit_requirements.txt"
+        )
+        bin_dir = os.path.join(
+            self._bin_dir,
+            self._python_version_dot_format,
+        )
+        bin_reqs_path = os.path.join(
+            bin_dir,
+            "explicit_requirements.txt"
+        )
 
         for path in [source_dir, bin_dir]:
             if not os.path.isdir(path):
@@ -260,6 +198,7 @@ class Updater(object):
             self._clean_pip()
 
         dependencies = self._get_dependencies_to_install()
+        print(f"List of dependencies to install: {dependencies}")
         self._update_requirements_file(dependencies)
 
 

--- a/resources/python/update_requirements.py
+++ b/resources/python/update_requirements.py
@@ -100,16 +100,13 @@ class Updater(object):
         pip_cmd = "python -m pip".split() + cmd.split()
         try:
             output = subprocess.check_output(pip_cmd)
-        except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError:
             raise UpdateException(
                 "Error running pip command: {}\n{}".format(
                     " ".join(pip_cmd),
-                    e.output,
+                    output,
                 )
             )
-
-        if self._is_python_3:
-            output = output.decode("utf-8")
 
         return output
 

--- a/resources/python/update_requirements.py
+++ b/resources/python/update_requirements.py
@@ -100,16 +100,16 @@ class Updater(object):
         pip_cmd = "python -m pip".split() + cmd.split()
         try:
             output = subprocess.check_output(pip_cmd)
-
-            if self._is_python_3:
-                output = output.decode("utf-8")
-        except subprocess.CalledProcessError:
+        except subprocess.CalledProcessError as e:
             raise UpdateException(
                 "Error running pip command: {}\n{}".format(
                     " ".join(pip_cmd),
-                    output,
+                    e.output,
                 )
             )
+        
+        if self._is_python_3:
+            output = output.decode("utf-8")
 
         return output
 
@@ -209,6 +209,7 @@ class Updater(object):
 
         dependencies = self._get_dependencies_to_install()
         print(f"List of dependencies to install: {dependencies}")
+
         self._update_requirements_file(dependencies)
 
 

--- a/resources/python/update_requirements.py
+++ b/resources/python/update_requirements.py
@@ -97,21 +97,21 @@ class Updater(object):
 
     def _pip(self, cmd):
         """Run the pip command."""
+        print(f"Executing pip command: {cmd}")
+
         pip_cmd = "python -m pip".split() + cmd.split()
         try:
             output = subprocess.check_output(pip_cmd)
         except subprocess.CalledProcessError as e:
             raise UpdateException(
-                "Error running pip command: {}\n{}".format(
+                "Error running pip command: {}\nReturn Code:{}\n{}".format(
                     " ".join(pip_cmd),
-                    e.output,
+                    e.returncode,
+                    e.stderr.decode("utf-8"),
                 )
             )
-        
-        if self._is_python_3:
-            output = output.decode("utf-8")
 
-        return output
+        return output.decode("utf-8")
 
     @staticmethod
     def _git(cmd):

--- a/resources/python/update_requirements.py
+++ b/resources/python/update_requirements.py
@@ -106,6 +106,15 @@ class Updater(object):
             "explicit_requirements.txt"
         )
 
+        self._source_reqs_3_11_dir = os.path.join(
+            self._sources_dir,
+            "3.11",
+        )
+        self._source_reqs_3_11_path = os.path.join(
+            self._source_reqs_3_11_dir,
+            "explicit_requirements.txt"
+        )
+
         self._bin_reqs_3_7_dir = os.path.join(
             self._bin_dir,
             "3.7",
@@ -130,6 +139,15 @@ class Updater(object):
         )
         self._bin_reqs_3_10_path = os.path.join(
             self._bin_reqs_3_10_dir,
+            "explicit_requirements.txt"
+        )
+
+        self._bin_reqs_3_11_dir = os.path.join(
+            self._bin_dir,
+            "3.11",
+        )
+        self._bin_reqs_3_11_path = os.path.join(
+            self._bin_reqs_3_11_dir,
             "explicit_requirements.txt"
         )
 

--- a/resources/python/update_requirements.py
+++ b/resources/python/update_requirements.py
@@ -108,7 +108,7 @@ class Updater(object):
                 "Error running pip command: {}\nReturn Code:{}\n{}".format(
                     " ".join(pip_cmd),
                     e.returncode,
-                    e.stderr.decode("utf-8"),
+                    e.stderr,
                 )
             )
         

--- a/resources/python/update_requirements.py
+++ b/resources/python/update_requirements.py
@@ -108,7 +108,7 @@ class Updater(object):
                 "Error running pip command: {}\nReturn Code:{}\n{}".format(
                     " ".join(pip_cmd),
                     e.returncode,
-                    e.stderr,
+                    e.output,
                 )
             )
         

--- a/resources/python/update_requirements.py
+++ b/resources/python/update_requirements.py
@@ -98,8 +98,6 @@ class Updater(object):
 
     def _pip(self, cmd):
         """Run the pip command."""
-        print(f"Executing pip command: {cmd}")
-
         pip_cmd = "python -m pip".split() + cmd.split()
         try:
             output = subprocess.check_output(pip_cmd)
@@ -138,6 +136,7 @@ class Updater(object):
             self._pip("install -r requirements/{}/requirements.txt".format(
                 self._python_version_dot_format
             ))
+            print("All dependencies installed.")
 
             # list everything that was installed.
             freeze_list = self._pip_freeze()

--- a/resources/python/update_requirements.py
+++ b/resources/python/update_requirements.py
@@ -185,12 +185,14 @@ class Updater(object):
 
     def _get_dependencies_to_install(self):
         """Retrieve the full list of dependencies after a pip install."""
-        if self._pip_freeze():
+        freeze_list = self._pip_freeze()
+        if freeze_list:
             raise UpdateException(
                 "Please clean up your Python installation from any "
                 "dependencies by uninstalling all of them or pip freeze "
                 "will contain too many dependencies.\nYou can clean pip "
-                "using `update_requirements.py --clean-pip`"
+                "using `update_requirements.py --clean-pip`.\n"
+                f"List of detected dependencies: {freeze_list}"
             )
 
         try:


### PR DESCRIPTION
- Refactor some stuff to make it easier to add new versions in the future
- Print messages in console when a version is not available. Useful for debugging.
- Downgrade `setuptools` for Python 3.7 that was causing issues.