### PR TITLE
SG-37292 Update PySide6 set option syntax

### DIFF
--- a/python/tk_framework_desktopserver/process_manager.py
+++ b/python/tk_framework_desktopserver/process_manager.py
@@ -323,7 +323,9 @@ class ProcessManager(object):
 
     def _pick_file_or_directory_in_main_thread(self, multi=False):
         dialog = SgtkFileDialog(multi, None)
-        dialog.setResolveSymlinks(False)
+        options = dialog.options()
+        options |= QtGui.QFileDialog.DontResolveSymlinks
+        dialog.setOptions(options)
 
         # Get result.
         result = dialog.exec_()


### PR DESCRIPTION
Method [setResolveSymlinks()](https://doc.qt.io/qtforpython-5/PySide2/QtWidgets/QFileDialog.html#PySide2.QtWidgets.PySide2.QtWidgets.QFileDialog.setResolveSymlinks) is deprecated in PySide2/PySide6. Switched to [setOptions()](https://doc.qt.io/qtforpython-6/PySide6/QtWidgets/QFileDialog.html#PySide6.QtWidgets.QFileDialog.setOptions) which is backward compatible to PySide2 as well.