### PR TITLE
SG-38248 Update cryptography to 44.0.1

### DIFF
--- a/resources/python/requirements/3.10/requirements.txt
+++ b/resources/python/requirements/3.10/requirements.txt
@@ -1,7 +1,7 @@
 Twisted==24.10.0
 certifi==2024.12.14
 autobahn==22.12.1
-pyOpenSSL==24.2.1
+pyOpenSSL==25.0.0
 service-identity==21.1.0
 
 # When updating certifi to match the version released with Desktop, some other unrelated modules (that are second

--- a/resources/python/requirements/3.10/requirements.txt
+++ b/resources/python/requirements/3.10/requirements.txt
@@ -9,7 +9,7 @@ service-identity==21.1.0
 # modules and rebuild the binaries
 attrs==22.2.0
 cffi==1.15.1
-cryptography==43.0.1 # Only for SAST. Should be also updated in resources/python/update_requirements.py
+cryptography==44.0.1 # Only for SAST.
 hyperlink==21.0.0
 idna==3.7
 six==1.16.0

--- a/resources/python/requirements/3.11/requirements.txt
+++ b/resources/python/requirements/3.11/requirements.txt
@@ -1,7 +1,7 @@
 Twisted==24.10.0
 certifi==2024.12.14
 autobahn==22.12.1
-pyOpenSSL==24.2.1
+pyOpenSSL==25.0.0
 service-identity==21.1.0
 
 # When updating certifi to match the version released with Desktop, some other unrelated modules (that are second

--- a/resources/python/requirements/3.11/requirements.txt
+++ b/resources/python/requirements/3.11/requirements.txt
@@ -9,7 +9,7 @@ service-identity==21.1.0
 # modules and rebuild the binaries
 attrs==22.2.0
 cffi==1.15.1
-cryptography==43.0.1 # Only for SAST. Should be also updated in resources/python/update_requirements.py
+cryptography==44.0.1 # Only for SAST.
 hyperlink==21.0.0
 idna==3.7
 six==1.16.0

--- a/resources/python/requirements/3.7/requirements.txt
+++ b/resources/python/requirements/3.7/requirements.txt
@@ -1,7 +1,7 @@
 Twisted==22.10.0 # This is the last version that supports Python 3.7
 certifi==2024.12.14
 autobahn==22.12.1
-pyOpenSSL==24.2.1
+pyOpenSSL==25.0.0
 service_identity==21.1.0
 
 # When updating certifi to match the version released with Desktop, some other unrelated modules (that are second

--- a/resources/python/requirements/3.7/requirements.txt
+++ b/resources/python/requirements/3.7/requirements.txt
@@ -9,7 +9,7 @@ service_identity==21.1.0
 # modules and rebuild the binaries
 attrs==22.2.0
 cffi==1.15.1
-cryptography==43.0.1 # Only for SAST. Should be also updated in resources/python/update_requirements.py
+cryptography==44.0.1 # Only for SAST.
 hyperlink==21.0.0
 idna==3.7
 six==1.16.0

--- a/resources/python/requirements/3.9/requirements.txt
+++ b/resources/python/requirements/3.9/requirements.txt
@@ -1,7 +1,7 @@
 Twisted==24.10.0
 certifi==2024.12.14
 autobahn==22.12.1
-pyOpenSSL==24.2.1
+pyOpenSSL==25.0.0
 service-identity==21.1.0
 
 # When updating certifi to match the version released with Desktop, some other unrelated modules (that are second

--- a/resources/python/requirements/3.9/requirements.txt
+++ b/resources/python/requirements/3.9/requirements.txt
@@ -9,7 +9,7 @@ service-identity==21.1.0
 # modules and rebuild the binaries
 attrs==22.2.0
 cffi==1.15.1
-cryptography==43.0.1 # Only for SAST. Should be also updated in resources/python/update_requirements.py
+cryptography==44.0.1 # Only for SAST.
 hyperlink==21.0.0
 idna==3.7
 six==1.16.0


### PR DESCRIPTION
- Base branch is #291 to prevent CI issues
- Bump PyOpenSSL to 25.0.0 because of dependency conflicts caused by the new version of cryptography