### PR TITLE
SG-41264 Fixup exception instance don't all have a message attribute

### DIFF
--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -772,7 +772,12 @@ class ShotgunAPI(object):
             self.host.reply(reply)
         except Exception as e:
             logger.exception(e)
-            self.host.report_error(e.message)
+            if hasattr(e, "message"):
+                self.host.report_error(e.message)
+            elif e.args:
+                self.host.report_error(e.args[0])
+            else:
+                self.host.report_error("unknown error")
 
     def pick_file_or_directory(self, data):
         """

--- a/python/tk_framework_desktopserver/shotgun/api_v2.py
+++ b/python/tk_framework_desktopserver/shotgun/api_v2.py
@@ -775,7 +775,7 @@ class ShotgunAPI(object):
             if hasattr(e, "message"):
                 self.host.report_error(e.message)
             elif e.args:
-                self.host.report_error(e.args[0])
+                self.host.report_error(str(e.args[0]))
             else:
                 self.host.report_error("unknown error")
 


### PR DESCRIPTION
AttributeError: 'Exception' object has no attribute 'message'