### PR TITLE
SG-44793 Strip common .tkdeploy exclusions now covered by global defaults

### DIFF
--- a/.tkdeploy
+++ b/.tkdeploy
@@ -1,11 +1,11 @@
 [packaging]
 exclude=
-    # Remove CI files.
-    .travis.yml*
-    appveyor.yml
-    # Remove unneeded files.
-    tests
+    azure-pipelines
     resources/python/build
-    resources/python/*.txt
-    resources/python/*.sh
+    resources/python/pipelines
     resources/python/*.bat
+    resources/python/*.md
+    resources/python/*.ps1
+    resources/python/*.py
+    resources/python/*.sh
+    resources/python/*.txt

--- a/.tkdeploy
+++ b/.tkdeploy
@@ -1,6 +1,5 @@
 [packaging]
 exclude=
-    azure-pipelines
     resources/python/build
     resources/python/pipelines
     resources/python/*.bat


### PR DESCRIPTION
## Problem
`tk-framework-desktopserver` was shipping several files that should never reach App Store installs: `tests/`, `.travis.yml`, `appveyor.yml`, and the `azure-pipelines/` directory.

## Changes
Common CI/dev entries (`tests`, `.travis.yml`, `appveyor.yml`) are now covered by global defaults added to the App Store publish tooling. The `.tkdeploy` is simplified to only the repo-specific entries: the `azure-pipelines/` directory (a folder distinct from `azure-pipelines.yml` which is handled globally) and the `resources/python/` build artefacts.

Note: these changes take effect only once the corresponding upstream tooling change is merged.

## Related PRs
- shotgunsoftware/tk-core#1130 — same cleanup for tk-core
- shotgunsoftware/tk-desktop#226 — same cleanup for tk-desktop

## Testing
Confirmed all removed entries are covered by the new global defaults. The retained `resources/python/*` and `azure-pipelines` entries are specific to this repo.
