### PR TITLE
SG-44961 Fix cp932 UnicodeDecodeError reading subprocess stderr on Japanese Windows

### DIFF
--- a/python/tk_framework_desktopserver/command.py
+++ b/python/tk_framework_desktopserver/command.py
@@ -226,11 +226,18 @@ class Command(object):
             )
             process.wait()
 
-            # Read back the output from the two.
-            with open(stdout_path, "rt") as stdout_file:
+            # Read back the output from the two. Decode as utf-8 with
+            # errors="replace" rather than relying on the OS locale codec:
+            # on non-utf-8 locales (e.g. cp932 on Japanese Windows) open()
+            # would otherwise raise UnicodeDecodeError on non-ASCII output.
+            with open(
+                stdout_path, "rt", encoding="utf-8", errors="replace"
+            ) as stdout_file:
                 stdout_lines = [l for l in stdout_file]
 
-            with open(stderr_path) as stderr_file:
+            with open(
+                stderr_path, "rt", encoding="utf-8", errors="replace"
+            ) as stderr_file:
                 stderr_lines = [l for l in stderr_file]
 
             # Track the result code.
@@ -240,7 +247,7 @@ class Command(object):
             logger.exception("Error running subprocess:")
 
             ret = 1
-            stderr_lines = [traceback.format_exc().split()]
+            stderr_lines = traceback.format_exc().split()
             stderr_lines.append("%s" % args)
 
         # Don't lose any sleep over temporary files that can't be deleted.


### PR DESCRIPTION
Jira: [SG-44961](https://autodesk.atlassian.net/browse/SG-44961)

## Problem

On Japanese Windows, `tk-framework-desktopserver` crashes while reading a launched subprocess's stderr. Reported by SUBARU Corp. when opening a PSD from Flow Production Tracking with Photoshop 2026 (27.8) using a Japanese Photoshop UI. The same code is present unchanged on `master`, so this has effectively always been broken on non-utf-8 locales.

There are two distinct defects in `command.py`, both in `_call_cmd_win32`.

**Bug 1 (trigger):** the stdout/stderr temp files are read with no explicit encoding, so `open()` uses the OS locale codec, which is cp932 on Japanese Windows. Non-ASCII subprocess output (byte `0x97`) then raises `UnicodeDecodeError: 'cp932' codec can't decode byte 0x97`.

**Bug 2 (turns it into a crash):** the win32 exception handler wrapped the traceback line list inside another list (`stderr_lines = [traceback.format_exc().split()]`), so `"".join(stderr_lines)` in `call_cmd` raised `TypeError: sequence item 0: expected str instance, list found`. The Unix path assigns the list directly and is correct.

## Fix

Decode both temp files as utf-8 with `errors="replace"` so the reader never crashes regardless of what the DCC emits, and assign the traceback list directly in the win32 exception handler to match the Unix implementation.

## Testing

Confirmed against the exact read/join logic: reading a stderr temp file containing byte `0x97` as cp932 raises `UnicodeDecodeError` inside the `try`, and the malformed handler then produces the `TypeError` seen in the customer log. With the fix, the same input decodes with a replacement character and does not crash.

QA reproduction recipe (Japanese system locale) is documented on the Jira ticket. English/Western Windows (cp1252) does not reproduce this because byte `0x97` is valid in cp1252.


[SG-44961]: https://autodesk.atlassian.net/browse/SG-44961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ